### PR TITLE
Split generation of enrolment strings from generation of QR codes

### DIFF
--- a/library/tiqr/Tiqr/API/Client.php
+++ b/library/tiqr/Tiqr/API/Client.php
@@ -58,7 +58,8 @@ class Tiqr_API_Client
         if (2 == substr($result->code, 0, 1)) {
             return $result;
         } elseif (is_object($result->body)) {
-            throw new Exception($result->body->message, $result->code);
+            throw new Exception($result->body->error, $result->code);
+
         } else {
             throw new Exception('', $result->code);
         }

--- a/library/tiqr/Tiqr/Message/APNS.php
+++ b/library/tiqr/Tiqr/Message/APNS.php
@@ -78,7 +78,7 @@ class Tiqr_Message_APNS extends Tiqr_Message_Abstract
         $message->setSound('default');
         $message->setExpire(30);
         foreach ($this->getCustomProperties() as $name => $value) {
-            $message->addCustomProperty($name, $value);
+            $message->addCustomData($name, $value);
         }
 
         try {

--- a/library/tiqr/Tiqr/Message/Exception/AuthFailure.php
+++ b/library/tiqr/Tiqr/Message/Exception/AuthFailure.php
@@ -19,7 +19,7 @@
 
 
 /** @internal includes */
-require_once 'Message/Exception.php';
+require_once('Tiqr/Message/Exception.php');
 
 /**
  * Exception in case of an authentication failure for the messaging service.

--- a/library/tiqr/Tiqr/Message/Exception/InvalidAddress.php
+++ b/library/tiqr/Tiqr/Message/Exception/InvalidAddress.php
@@ -19,7 +19,7 @@
 
 
 /** @internal includes */
-require_once 'Message/Exception.php';
+require_once('Tiqr/Message/Exception.php');
 
 /**
  * Exception in case of an unknown or invalid address.

--- a/library/tiqr/Tiqr/Message/Exception/SendFailure.php
+++ b/library/tiqr/Tiqr/Message/Exception/SendFailure.php
@@ -19,7 +19,7 @@
 
 
 /** @internal includes */
-require_once 'Message/Exception.php';
+//require_once 'Message/Exception.php';
 
 /**
  * Exception in case of a message that cannot be send.

--- a/library/tiqr/Tiqr/Message/Exception/SendFailure.php
+++ b/library/tiqr/Tiqr/Message/Exception/SendFailure.php
@@ -19,7 +19,7 @@
 
 
 /** @internal includes */
-//require_once 'Message/Exception.php';
+require_once('Tiqr/Message/Exception.php');
 
 /**
  * Exception in case of a message that cannot be send.

--- a/library/tiqr/Tiqr/Message/GCM.php
+++ b/library/tiqr/Tiqr/Message/GCM.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * This file is part of the tiqr project.
+ * 
+ * The tiqr project aims to provide an open implementation for 
+ * authentication using mobile devices. It was initiated by 
+ * SURFnet and developed by Egeniq.
+ *
+ * More information: http://www.tiqr.org
+ *
+ * @author Peter Verhage <peter@egeniq.com>
+ * 
+ * @package tiqr
+ *
+ * @license New BSD License - See LICENSE file for details.
+ *
+ * @copyright (C) 2010-2011 SURFnet BV
+ */
+
+
+/** @internal base includes */
+require_once('Tiqr/Message/Abstract.php');
+
+//require_once('Zend/Gdata/ClientLogin.php');
+require_once 'Zend/Mobile/Push/Gcm.php';
+require_once 'Zend/Mobile/Push/Message/Gcm.php';
+
+/**
+ * Android Cloud To Device Messaging message.
+ * @author peter
+ */
+class Tiqr_Message_C2DM extends Tiqr_Message_Abstract
+{
+    private static $_services = array();
+    
+    /**
+     * Factory method for returning a C2DM service instance for the given 
+     * configuration options.
+     *
+     * @param array $options configuration options
+     *
+     * @return Zend_Service_Google_C2dm service instance
+     *
+     * @throws Tiqr_Message_Exception_AuthFailure
+     */
+    private static function _getService($options)
+    {
+        $apikey      = $options['gcm.apikey'];
+        $application = $options['gcm.application'];
+
+        $key = "{apikey}@{$application}";
+
+        if (!isset(self::$_services[$key])) {
+            $service = new Zend_Mobile_Push_Gcm();
+            $service->setApiKey($apikey);
+            self::$_services[$key] = $service;
+        }
+        
+        return self::$_services[$key];
+    }
+    
+    /**
+     * Send message.
+     *
+     * @throws Tiqr_Message_Exception_AuthFailure
+     * @throws Tiqr_Message_Exception_SendFailure
+     * @throws Tiqr_Message_Exception_InvalidDevice     
+     */
+    public function send()
+    {
+        $service = self::_getService($this->getOptions());
+        
+        $data = $this->getCustomProperties();
+        $data['text'] = $this->getText();
+
+        $message = new Zend_Mobile_Push_Message_Gcm();
+        $message->addToken($this->getAddress());
+        $message->setId($this->getId()); // TODO: needed?
+        $message->setData($data);
+
+        try {
+            $response = $service->send($message);
+        } catch (Zend_Htpp_Client_Exception $e) {
+            throw new Tiqr_Message_Exception_SendFailure("HTTP client error", true, $e);
+        } catch (Zend_Mobile_Push_Exception_ServerUnavailable $e) {
+            throw new Tiqr_Message_Exception_SendFailure("Server unavailable", true, $e);
+        } catch (Zend_Mobile_Push_Exception_InvalidAuthToken $e) {
+            throw new Tiqr_Message_Exception_InvalidDevice("Invalid token", $e);
+        } catch (Zend_Mobile_Push_Exception_InvalidPayload $e) {
+            throw new Tiqr_Message_Exception_InvalidDevice("Payload too large", $e);
+        } catch (Zend_Mobile_Push_Exception $e) {
+            throw new Tiqr_Message_Exception_SendFailure("General send error", false, $e);
+        }
+
+        // handle all errors and registration_id's
+        foreach ($response->getResults() as $k => $v) {
+            if (isset($v['registration_id'])) {
+                error_log("$k has a new registration id of: " . $v['registration_id']);
+            }
+            if (isset($v['error'])) {
+                error_log("$k had an error of: " . $v['error']);
+            }
+            if (isset($v['message_id'])) { // success
+            }
+        }
+
+    }
+}

--- a/library/tiqr/Tiqr/Message/GCM.php
+++ b/library/tiqr/Tiqr/Message/GCM.php
@@ -29,17 +29,17 @@ require_once 'Zend/Mobile/Push/Message/Gcm.php';
  * Android Cloud To Device Messaging message.
  * @author peter
  */
-class Tiqr_Message_C2DM extends Tiqr_Message_Abstract
+class Tiqr_Message_GCM extends Tiqr_Message_Abstract
 {
     private static $_services = array();
     
     /**
-     * Factory method for returning a C2DM service instance for the given 
+     * Factory method for returning a GCM service instance for the given 
      * configuration options.
      *
      * @param array $options configuration options
      *
-     * @return Zend_Service_Google_C2dm service instance
+     * @return Zend_Service_Google_Gcm service instance
      *
      * @throws Tiqr_Message_Exception_AuthFailure
      */
@@ -75,7 +75,7 @@ class Tiqr_Message_C2DM extends Tiqr_Message_Abstract
 
         $message = new Zend_Mobile_Push_Message_Gcm();
         $message->addToken($this->getAddress());
-        $message->setId($this->getId()); // TODO: needed?
+        $message->setId($this->getId()); // TODO: GCM equivalent needed?
         $message->setData($data);
 
         try {
@@ -85,7 +85,7 @@ class Tiqr_Message_C2DM extends Tiqr_Message_Abstract
         } catch (Zend_Mobile_Push_Exception_ServerUnavailable $e) {
             throw new Tiqr_Message_Exception_SendFailure("Server unavailable", true, $e);
         } catch (Zend_Mobile_Push_Exception_InvalidAuthToken $e) {
-            throw new Tiqr_Message_Exception_InvalidDevice("Invalid token", $e);
+            throw new Tiqr_Message_Exception_InvalidDevice("Invalid token", $e);	// TODO: change exception type
         } catch (Zend_Mobile_Push_Exception_InvalidPayload $e) {
             throw new Tiqr_Message_Exception_InvalidDevice("Payload too large", $e);
         } catch (Zend_Mobile_Push_Exception $e) {

--- a/library/tiqr/Tiqr/Service.php
+++ b/library/tiqr/Tiqr/Service.php
@@ -253,7 +253,7 @@ class Tiqr_Service
     /**
      * Send a push notification to a user containing an authentication challenge
      * @param String $sessionKey          The session key identifying this authentication session
-     * @param String $notificationType    Notification type, e.g. APNS, C2DM, (SMS?)
+     * @param String $notificationType    Notification type, e.g. APNS, C2DM, GCM, (SMS?)
      * @param String $notificationAddress Notification address, e.g. device token, phone number etc.
      *
      * @return boolean True if the notification was sent succesfully, false if not.
@@ -263,7 +263,6 @@ class Tiqr_Service
     public function sendAuthNotification($sessionKey, $notificationType, $notificationAddress)
     {
         try {
-            if( 'C2DM' === $notificationType) $notificationType = 'GCM'; // C2DM defunct per 20150401
             $class = "Tiqr_Message_{$notificationType}";
             if (!class_exists($class)) {
                 return false;
@@ -637,7 +636,7 @@ class Tiqr_Service
      */
     public function translateNotificationAddress($notificationType, $notificationAddress)
     {
-        if ($notificationType == 'APNS' || $notificationType == 'C2DM') {
+        if ($notificationType == 'APNS' || $notificationType == 'C2DM' || $notificationType == 'GCM') {
             return $this->_deviceStorage->getDeviceToken($notificationAddress);
         } else {
             return $notificationAddress;

--- a/library/tiqr/Tiqr/Service.php
+++ b/library/tiqr/Tiqr/Service.php
@@ -301,13 +301,6 @@ class Tiqr_Service
     }
 
     /**
-     */
-    public function generateEnrollString($metadataUrl)
-    {
-        return $this->_getEnrollString($metadataUrl);
-    }
-
-    /**
      * Start an authentication session. This generates a challenge for this 
      * session and stores it in memory. The returned sessionKey should be used
      * throughout the authentication process.
@@ -431,6 +424,15 @@ class Tiqr_Service
         $enrollmentString = $this->_getEnrollString($metadataUrl);
         
         QRcode::png($enrollmentString, false, 4, 5);
+    }
+
+    /**
+     * Generate an enrol string
+     * This string can be used to feed to a QR code generator
+     */
+    public function generateEnrollString($metadataUrl)
+    {
+        return $this->_getEnrollString($metadataUrl);
     }
     
     /**
@@ -685,6 +687,8 @@ class Tiqr_Service
     }
 
     /**
+     * Generate an enrollment string
+     * @param String $metadataUrl The URL you provide to the phone to retrieve metadata.
      */
     protected function _getEnrollString($metadataUrl)
     {

--- a/library/tiqr/Tiqr/Service.php
+++ b/library/tiqr/Tiqr/Service.php
@@ -263,6 +263,7 @@ class Tiqr_Service
     public function sendAuthNotification($sessionKey, $notificationType, $notificationAddress)
     {
         try {
+            if( 'C2DM' === $notificationType) $notificationType = 'GCM'; // C2DM defunct per 20150401
             $class = "Tiqr_Message_{$notificationType}";
             if (!class_exists($class)) {
                 return false;

--- a/library/tiqr/Tiqr/Service.php
+++ b/library/tiqr/Tiqr/Service.php
@@ -270,7 +270,7 @@ class Tiqr_Service
             }
 
             $message = new $class($this->_options);
-            $message->setId($sessionKey);
+            $message->setId(time());
             $message->setText("Please authenticate for " . $this->_name);
             $message->setAddress($notificationAddress);
             $message->setCustomProperty('challenge', $this->_getChallengeUrl($sessionKey));

--- a/library/tiqr/Tiqr/Service.php
+++ b/library/tiqr/Tiqr/Service.php
@@ -301,6 +301,13 @@ class Tiqr_Service
     }
 
     /**
+     */
+    public function generateEnrollString($metadataUrl)
+    {
+        return $this->_getEnrollString($metadataUrl);
+    }
+
+    /**
      * Start an authentication session. This generates a challenge for this 
      * session and stores it in memory. The returned sessionKey should be used
      * throughout the authentication process.
@@ -421,7 +428,7 @@ class Tiqr_Service
      */
     public function generateEnrollmentQR($metadataUrl) 
     { 
-        $enrollmentString = $this->_protocolEnroll."://".$metadataUrl;
+        $enrollmentString = $this->_getEnrollString($metadataUrl);
         
         QRcode::png($enrollmentString, false, 4, 5);
     }
@@ -676,7 +683,14 @@ class Tiqr_Service
         // Last bit is the spIdentifier
         return $this->_protocolAuth."://".(!is_null($userId)?urlencode($userId).'@':'').$this->getIdentifier()."/".$sessionKey."/".$challenge."/".urlencode($spIdentifier)."/".$this->_protocolVersion;
     }
-    
+
+    /**
+     */
+    protected function _getEnrollString($metadataUrl)
+    {
+        return $this->_protocolEnroll."://".$metadataUrl;
+    }
+
     /**
      * Generate a unique random key to be used to store temporary session
      * data.


### PR DESCRIPTION
To enable the use of different QR code libraries (e.g. based on Google Chart APIs or client-side JavaScript libraries) it helps if generating QR codes is independent from generating the enrolment strings themselves.
