### PR TITLE
Test openssl_random_pseudo_bytes generated a value

### DIFF
--- a/library/tiqr/Tiqr/Random.php
+++ b/library/tiqr/Tiqr/Random.php
@@ -40,11 +40,13 @@ class Tiqr_Random
     {
        if(function_exists('openssl_random_pseudo_bytes')) {
             $rnd = openssl_random_pseudo_bytes($length, $strong);
-            if($strong === TRUE) {
+            if($strong === TRUE && $rnd !== FALSE) {
                 return $rnd;
             }
         }
-        
+
+        // When openssl_random_pseudo_bytes failed, fall back on a mt_rand based string.
+
         $rnd='';
         
         for ($i=0;$i<$length;$i++) {


### PR DESCRIPTION
If the value is false, fall back on the fallback behaviour. In some
cases the method would now have returned false (when the function was
unable to generate the random bytes.

See https://www.pivotaltracker.com/story/show/158356708