### PR TITLE
Add firebase as fallback for GCM push notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,8 @@
     "require": {
         "zendframework/zendframework1": "~1.12",
         "kairos/phpqrcode": "~1.0",
-        "ext-gd": "*"
+        "ext-gd": "*",
+        "ext-curl": "*",
+        "ext-json": "*"
     }
 }

--- a/library/tiqr/Tiqr/Message/Exception/MismatchSenderId.php
+++ b/library/tiqr/Tiqr/Message/Exception/MismatchSenderId.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This file is part of the tiqr project.
+ * 
+ * The tiqr project aims to provide an open implementation for 
+ * authentication using mobile devices. It was initiated by 
+ * SURFnet and developed by Egeniq.
+ *
+ * More information: http://www.tiqr.org
+ *
+ * @author Peter Verhage <peter@egeniq.com>
+ * 
+ * @package tiqr
+ *
+ * @license New BSD License - See LICENSE file for details.
+ *
+ * @copyright (C) 2010-2019 SURFnet BV
+ */
+
+
+/** @internal includes */
+require_once('Tiqr/Message/Exception.php');
+
+/**
+ * Exception in case of a message that cannot be send.
+ */
+class Tiqr_Message_Exception_MismatchSenderId extends Tiqr_Message_Exception
+{
+    private $_temporary;
+    
+    /**
+     * Constructor
+     *
+     * @param string    $message    exception message
+     * @param boolean   $temporary  temporary failure?
+     * @param Exception $parent     parent exception
+     */
+    public function __construct($message, $temporary=false, Exception $parent=null)
+    {
+        parent::__construct($message, $parent);
+        $this->_temporary = $temporary;
+    }
+    
+    /**
+     * Is temporary failure? E.g. it's possible to try again later on?
+     *
+     * @return boolean is temporary failure?
+     */
+    public function isTemporary()
+    {
+        return $this->_temporary;
+    }
+}

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * This file is part of the tiqr project.
+ * 
+ * The tiqr project aims to provide an open implementation for 
+ * authentication using mobile devices. It was initiated by 
+ * SURFnet and developed by Egeniq.
+ *
+ * More information: http://www.tiqr.org
+ *
+ * @author Joost van Dijk <joost.vandijk@surfnet.nl>
+ * 
+ * @package tiqr
+ *
+ * @license New BSD License - See LICENSE file for details.
+ *
+ * @copyright (C) 2010-2015 SURFnet BV
+ */
+
+
+/** @internal base includes */
+require_once('Tiqr/Message/Abstract.php');
+
+/**
+ * Android Cloud To Device Messaging message.
+ * @author peter
+ */
+class Tiqr_Message_FCM extends Tiqr_Message_Abstract
+{
+    /**
+     * Send message.
+     *
+     * @throws Tiqr_Message_Exception_AuthFailure
+     * @throws Tiqr_Message_Exception_SendFailure
+     */
+    public function send()
+    {
+        $options = $this->getOptions();
+        $apiKey = $options['firebase.apikey'];
+
+        $translatedAddress = $this->getAddress();
+        $name = $this->getText();
+        $url = $this->getCustomProperty('challenge');
+
+        $this->_sendFirebase($translatedAddress, "Please authenticate for " . $name, $url, $apiKey);
+    }
+
+    /**
+     * Send a message to a device using the firebase API key.
+     *
+     * @param $deviceToken string device ID
+     * @param $alert string alert message
+     * @param $challenge string tiqr challenge url
+     * @param $apiKey string api key for firebase
+     * @param Tiqr_Message_Exception $gcmException
+     *
+     * @throws Tiqr_Message_Exception_SendFailure
+     */
+    private function _sendFirebase($deviceToken, $alert, $challenge, $apiKey)
+    {
+        $msg = array(
+            'challenge' => $challenge,
+            'text'      => $alert,
+        );
+
+        $fields = array(
+            'registration_ids' => array($deviceToken),
+            'data' => $msg,
+        );
+
+        $headers = array(
+            'Authorization: key=' . $apiKey,
+            'Content-Type: application/json',
+        );
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, 'https://fcm.googleapis.com/fcm/send');
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($fields));
+        $result = curl_exec($ch);
+        $errors = curl_error($ch);
+        $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($result === false) {
+            throw new Tiqr_Message_Exception_SendFailure("Server unavailable", true);
+        }
+
+        if (!empty($errors)) {
+            throw new Tiqr_Message_Exception_SendFailure("Http error occurred: ". $errors, true);
+        }
+
+        if ($statusCode !== 200) {
+            throw new Tiqr_Message_Exception_SendFailure("Invalid status code", true);
+        }
+
+        // handle errors, ignoring registration_id's
+        $response = json_decode($result, true);
+        foreach ($response['results'] as $k => $v) {
+            if (isset($v['error'])) {
+                throw new Tiqr_Message_Exception_SendFailure("Error in GCM response: " . $v['error'], true);
+            }
+        }
+    }
+}

--- a/library/tiqr/Tiqr/Service.php
+++ b/library/tiqr/Tiqr/Service.php
@@ -281,6 +281,8 @@ class Tiqr_Service
     public function sendAuthNotification($sessionKey, $notificationType, $notificationAddress)
     {
         try {
+            $this->_notificationError = null;
+
             $class = "Tiqr_Message_{$notificationType}";
             if (!class_exists($class)) {
                 return false;
@@ -681,7 +683,7 @@ class Tiqr_Service
      */
     public function translateNotificationAddress($notificationType, $notificationAddress)
     {
-        if ($notificationType == 'APNS' || $notificationType == 'C2DM' || $notificationType == 'GCM') {
+        if ($notificationType == 'APNS' || $notificationType == 'C2DM' || $notificationType == 'GCM' || $notificationType == 'FCM') {
             return $this->_deviceStorage->getDeviceToken($notificationAddress);
         } else {
             return $notificationAddress;


### PR DESCRIPTION
Firebase should be used for fallback notifications if the GCM
notifications fail. This will be used to be able to migrate to the
newer Firebase notification system used for android.