### PR TITLE
Remove redundant 'Please authenticate for' text

### DIFF
--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -39,10 +39,10 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
         $apiKey = $options['firebase.apikey'];
 
         $translatedAddress = $this->getAddress();
-        $name = $this->getText();
+        $alertText = $this->getText();
         $url = $this->getCustomProperty('challenge');
 
-        $this->_sendFirebase($translatedAddress, "Please authenticate for " . $name, $url, $apiKey);
+        $this->_sendFirebase($translatedAddress, $alertText, $url, $apiKey);
     }
 
     /**


### PR DESCRIPTION
The text is already set by the service. Adding it twice leads to a confusing push notification message.

https://www.pivotaltracker.com/story/show/164797911