### PR TITLE
Log the http-statuscode and error received from firebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 composer.lock
 vendor
 .idea
-*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 composer.lock
 vendor
+.idea
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.2
 
 before_script:
   - composer self-update

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -1,15 +1,15 @@
 <?php
 /**
  * This file is part of the tiqr project.
- * 
- * The tiqr project aims to provide an open implementation for 
- * authentication using mobile devices. It was initiated by 
+ *
+ * The tiqr project aims to provide an open implementation for
+ * authentication using mobile devices. It was initiated by
  * SURFnet and developed by Egeniq.
  *
  * More information: http://www.tiqr.org
  *
  * @author Joost van Dijk <joost.vandijk@surfnet.nl>
- * 
+ *
  * @package tiqr
  *
  * @license New BSD License - See LICENSE file for details.
@@ -52,11 +52,12 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
      * @param $alert string alert message
      * @param $challenge string tiqr challenge url
      * @param $apiKey string api key for firebase
+     * @param $retry boolean is this a 2nd attempt
      * @param Tiqr_Message_Exception $gcmException
      *
      * @throws Tiqr_Message_Exception_SendFailure
      */
-    private function _sendFirebase($deviceToken, $alert, $challenge, $apiKey)
+    private function _sendFirebase($deviceToken, $alert, $challenge, $apiKey, $retry=false)
     {
         $msg = array(
             'challenge' => $challenge,
@@ -90,6 +91,13 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
 
         if (!empty($errors)) {
             throw new Tiqr_Message_Exception_SendFailure("Http error occurred: ". $errors, true);
+        }
+
+        // Wait and retry once in case of a 502 Bad Gateway error
+        if (($statusCode == 502) && !($retry)) {
+          sleep(2);
+          $this->_sendFirebase($deviceToken, $alert, $challenge, $apiKey, true);
+          return;
         }
 
         if ($statusCode !== 200) {

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -93,7 +93,7 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
         }
 
         if ($statusCode !== 200) {
-            throw new Tiqr_Message_Exception_SendFailure("Invalid status code : ".$statusCode, true);
+            throw new Tiqr_Message_Exception_SendFailure("Invalid status code : '".$statusCode."'. Response: ".$result, true);
         }
 
         // handle errors, ignoring registration_id's

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -84,6 +84,7 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
         $result = curl_exec($ch);
         $errors = curl_error($ch);
         $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $remoteip = curl_getinfo($ch,CURLINFO_PRIMARY_IP);
         curl_close($ch);
 
         if ($result === false) {
@@ -102,7 +103,7 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
         }
 
         if ($statusCode !== 200) {
-            throw new Tiqr_Message_Exception_SendFailure("Invalid status code : '".$statusCode."'. Response: ".$result, true);
+            throw new Tiqr_Message_Exception_SendFailure("Invalid status code : '".$statusCode."'. Server : ".$remoteip.". Response : ".$result, true);
         }
 
         // handle errors, ignoring registration_id's

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -67,6 +67,7 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
         $fields = array(
             'registration_ids' => array($deviceToken),
             'data' => $msg,
+            'time_to_live' => 300,
         );
 
         $headers = array(

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -93,7 +93,7 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
         }
 
         if ($statusCode !== 200) {
-            throw new Tiqr_Message_Exception_SendFailure("Invalid status code", true);
+            throw new Tiqr_Message_Exception_SendFailure("Invalid status code : ".$statusCode, true);
         }
 
         // handle errors, ignoring registration_id's

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -96,14 +96,14 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
         }
 
         // Wait and retry once in case of a 502 Bad Gateway error
-        if (($statusCode == 502) && !($retry)) {
+        if ($statusCode === 502 && !($retry)) {
           sleep(2);
           $this->_sendFirebase($deviceToken, $alert, $challenge, $apiKey, true);
           return;
         }
 
         if ($statusCode !== 200) {
-            throw new Tiqr_Message_Exception_SendFailure("Invalid status code : '".$statusCode."'. Server : ".$remoteip.". Response : ".$result, true);
+            throw new Tiqr_Message_Exception_SendFailure(sprintf('Invalid status code : %s. Server : %s. Response : "%s".', $statusCode, $remoteip, $result), true);
         }
 
         // handle errors, ignoring registration_id's

--- a/library/tiqr/tests/OcraTest.php
+++ b/library/tiqr/tests/OcraTest.php
@@ -1,15 +1,15 @@
 <?php
 /**
  * This file is part of the tiqr project.
- * 
- * The tiqr project aims to provide an open implementation for 
- * authentication using mobile devices. It was initiated by 
+ *
+ * The tiqr project aims to provide an open implementation for
+ * authentication using mobile devices. It was initiated by
  * SURFnet and developed by Egeniq.
  *
  * More information: http://www.tiqr.org
  *
  * @author Ivo Jansch <ivo@egeniq.com>
- * 
+ *
  * @package tiqr
  *
  * @license New BSD License - See LICENSE file for details.
@@ -19,52 +19,53 @@
 
 
 //require_once 'PHPUnit/Framework.php';
- 
+require_once 'PHPUnit/Autoload.php';
+
 require_once __DIR__ . '/../Tiqr/OATH/OCRA.php';
 
 class ArrayTest extends PHPUnit_Framework_TestCase
 {
-    
+
     public function decimalToHex($decimalChallenge)
     {
         return dechex($decimalChallenge);
-    }    
+    }
 
     public function testPlainChallengeResponse()
     {
 
-        $result = OCRA::generateOCRA("OCRA-1:HOTP-SHA1-6:QN08", 
-                                     "3132333435363738393031323334353637383930", 
+        $result = OCRA::generateOCRA("OCRA-1:HOTP-SHA1-6:QN08",
+                                     "3132333435363738393031323334353637383930",
                                      "",
-                                     $this->decimalToHex("00000000"), 
-                                     "", 
-                                     "", 
-                                     "");
-                                     
-        $this->assertEquals("237653", $result);
-        
-        $result = OCRA::generateOCRA("OCRA-1:HOTP-SHA1-6:QN08", 
-                                     "3132333435363738393031323334353637383930", 
-                                     "", 
-                                     $this->decimalToHex("77777777"), 
-                                     "", 
-                                     "", 
+                                     $this->decimalToHex("00000000"),
+                                     "",
+                                     "",
                                      "");
 
-        $this->assertEquals("224598", $result);        
+        $this->assertEquals("237653", $result);
+
+        $result = OCRA::generateOCRA("OCRA-1:HOTP-SHA1-6:QN08",
+                                     "3132333435363738393031323334353637383930",
+                                     "",
+                                     $this->decimalToHex("77777777"),
+                                     "",
+                                     "",
+                                     "");
+
+        $this->assertEquals("224598", $result);
     }
 
     public function testChallengeResponseWithSession()
-    {        
-        $result = OCRA::generateOCRA("OCRA-1:HOTP-SHA1-6:QN08-S", 
-                                     "3132333435363738393031323334353637383930", 
-                                     "", 
-                                     $this->decimalToHex("77777777"), 
-                                     "", 
-                                     "ABCDEFABCDEF", 
+    {
+        $result = OCRA::generateOCRA("OCRA-1:HOTP-SHA1-6:QN08-S",
+                                     "3132333435363738393031323334353637383930",
+                                     "",
+                                     $this->decimalToHex("77777777"),
+                                     "",
+                                     "ABCDEFABCDEF",
                                      "");
 
-        $this->assertEquals("675831", $result);        
+        $this->assertEquals("675831", $result);
     }
-    
+
 }


### PR DESCRIPTION
Try to debug / fix the "Invalid status code" errors received from FCM. Other improvements are added to this PR.

- Log http status code and response
- Retry once if a 502 gateway timeout is received
- Adjust TTL for messages