### PR TITLE
Feature/state storage pdo expiry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "ext-pdo_sqlite": "*"
+        "ext-pdo_sqlite": "*",
+        "mockery/mockery": "^1.3"
     }
 }

--- a/library/tiqr/Tiqr/StateStorage.php
+++ b/library/tiqr/Tiqr/StateStorage.php
@@ -71,9 +71,9 @@ class Tiqr_StateStorage
 
                 $pdoInstance = new PDO($options['dsn'],$options['username'],$options['password']);
                 // Set a hard-coded default for the probability the expired state is removed
-                // 10 translates to: expired entries are removed 10 in every 1000 write actions
-                $cleanupProbability = 10;
-                if (array_key_exists('cleanup_probability', $options) && is_int($options['cleanup_probability'])) {
+                // 0.1 translates to a 10% chance the garbage collection is executed
+                $cleanupProbability = 0.1;
+                if (array_key_exists('cleanup_probability', $options) && is_numeric($options['cleanup_probability'])) {
                     $cleanupProbability = $options['cleanup_probability'];
                 }
 

--- a/library/tiqr/Tiqr/StateStorage/Pdo.php
+++ b/library/tiqr/Tiqr/StateStorage/Pdo.php
@@ -41,10 +41,15 @@ class Tiqr_StateStorage_Pdo extends Tiqr_StateStorage_Abstract
      */
     private $cleanupProbability;
 
-    public function __construct(PDO $pdoInstance, string $tablename, int $cleanupProbability)
+    /**
+     * @param PDO $pdoInstance The PDO instance where all state storage operations are performed on
+     * @param string $tablename The tablename that is used for storing and retrieving the state storage
+     * @param int $cleanupProbability The probability the expired state storage items are removed on a 'setValue' call. Example usage: 0 = never, 0.5 = 50% chance, 1 = always
+     */
+    public function __construct(PDO $pdoInstance, string $tablename, float $cleanupProbability)
     {
-        if ($cleanupProbability < 1 || $cleanupProbability > 1000) {
-            throw new RuntimeException('The probability for removing the expired state should be expressed in a value between 1 and 1000.');
+        if ($cleanupProbability < 0 || $cleanupProbability > 1) {
+            throw new RuntimeException('The probability for removing the expired state should be expressed in a floating point value between 0 and 1.');
         }
         $this->cleanupProbability = $cleanupProbability;
         $this->tablename = $tablename;
@@ -69,7 +74,7 @@ class Tiqr_StateStorage_Pdo extends Tiqr_StateStorage_Abstract
      */
     public function setValue($key, $value, $expire=0)
     {
-        if (rand(0, 1000) < $this->cleanupProbability) {
+        if (((float) rand() /(float) getrandmax()) < $this->cleanupProbability) {
             $this->cleanExpired();
         }
         if ($this->keyExists($key)) {

--- a/library/tiqr/tests/Tiqr_StateStoragePdoTest.php
+++ b/library/tiqr/tests/Tiqr_StateStoragePdoTest.php
@@ -40,7 +40,7 @@ class Tiqr_StateStoragePdoTest extends TestCase
 
         $pdoInstance = new PDO($dsn, null, null);
         $this->pdoInstance = m::mock($pdoInstance);
-        $this->stateStorage = new Tiqr_StateStorage_Pdo($this->pdoInstance, 'state', 1000);
+        $this->stateStorage = new Tiqr_StateStorage_Pdo($this->pdoInstance, 'state', 1);
         $this->assertInstanceOf(Tiqr_StateStorage_Pdo::class, $this->stateStorage);
     }
 
@@ -77,17 +77,15 @@ class Tiqr_StateStoragePdoTest extends TestCase
     public function test_input_validation_for_cleanup_probability($incorrectValue)
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The probability for removing the expired state should be expressed in a value between 1 and 1000.');
+        $this->expectExceptionMessage('The probability for removing the expired state should be expressed in a floating point value between 0 and 1.');
         new Tiqr_StateStorage_Pdo(m::mock(PDO::class), 'tablename', $incorrectValue);
     }
 
     public function provideIncorrectCleanupProbabilityValues()
     {
         return [
-            'value too low' => [0],
-            'value too below zero' => [-1],
-            'value too high' => [1001],
-            'value too high close to overflow point' => [9223372036854775807],
+            'value too low' => [-1],
+            'value too high' => [1.001],
         ];
     }
 }

--- a/library/tiqr/tests/Tiqr_StateStoragePdoTest.php
+++ b/library/tiqr/tests/Tiqr_StateStoragePdoTest.php
@@ -1,0 +1,93 @@
+<?php
+
+require_once 'tiqr_autoloader.inc';
+
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class Tiqr_StateStoragePdoTest extends TestCase
+{
+    /**
+     * @var Tiqr_StateStorage_Pdo
+     */
+    private $stateStorage;
+
+    /**
+     * @var MockInterface|PDO
+     */
+    private $pdoInstance;
+
+    private function makeTempDir() {
+        $tempName = tempnam(sys_get_temp_dir(),'Tiqr_StateStorageTest');
+        unlink($tempName);
+        mkdir($tempName);
+        return $tempName;
+    }
+
+    private function setUpDatabase(string $dsn)
+    {
+        // Create test database
+        $pdo = new PDO($dsn, null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $pdo->exec("CREATE TABLE state (key varchar(255) PRIMARY KEY, expire int, value text);");
+    }
+
+    protected function setUp(): void
+    {
+        $targetPath = $this->makeTempDir();
+        $dsn = 'sqlite:' . $targetPath . '/state.sq3';
+        $this->setUpDatabase($dsn);
+
+        $pdoInstance = new PDO($dsn, null, null);
+        $this->pdoInstance = m::mock($pdoInstance);
+        $this->stateStorage = new Tiqr_StateStorage_Pdo($this->pdoInstance, 'state', 1000);
+        $this->assertInstanceOf(Tiqr_StateStorage_Pdo::class, $this->stateStorage);
+    }
+
+    function test_called_clean_expired() {
+        // Here be dragons: first call to the PDO's prepare statement must be a DELETE query
+        // (clearing the expired entries)
+        $this->pdoInstance
+            ->shouldReceive('prepare')
+            ->once()
+            ->withArgs(function($query) {
+                $queryType = substr($query, 0,6);
+                // This assertion focusses on the Delete statement, let the others through without checking
+                if ($queryType === 'DELETE') {
+                    $this->assertStringContainsString('DELETE FROM state', $query);
+                    $this->assertStringContainsString('WHERE `expire` < ? AND NOT `expire` = 0', $query);
+                    return true;
+                }
+                $this->fail('The first call to the prepare PDO method should be with a DELETE statement');
+            })->andReturn(m::mock(PDOStatement::class)->shouldIgnoreMissing());
+        // The other prepare statements we don't care about, but they must be
+        // declared to prevent expectation errors. Covering them in the expectation above
+        // raises side effects, as it becomes impossible to tell in what order the prepare
+        // statement is called.
+        $this->pdoInstance
+            ->shouldReceive('prepare')
+            ->andReturn(m::mock(PDOStatement::class)->shouldIgnoreMissing());
+
+        $this->stateStorage->setValue('key', 'data', 1);
+    }
+
+    /**
+     * @dataProvider provideIncorrectCleanupProbabilityValues
+     */
+    public function test_input_validation_for_cleanup_probability($incorrectValue)
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The probability for removing the expired state should be expressed in a value between 1 and 1000.');
+        new Tiqr_StateStorage_Pdo(m::mock(PDO::class), 'tablename', $incorrectValue);
+    }
+
+    public function provideIncorrectCleanupProbabilityValues()
+    {
+        return [
+            'value too low' => [0],
+            'value too below zero' => [-1],
+            'value too high' => [1001],
+            'value too high close to overflow point' => [9223372036854775807],
+        ];
+    }
+}

--- a/library/tiqr/tests/Tiqr_StateStorageTest.php
+++ b/library/tiqr/tests/Tiqr_StateStorageTest.php
@@ -52,6 +52,7 @@ SQL
             'dsn' => $dsn,
             'username' => null,
             'password' => null,
+            'cleanup_probability' => 0.6
         );
         $ss=Tiqr_StateStorage::getStorage("pdo", $options);
         $this->assertInstanceOf(Tiqr_StateStorage_Pdo::class, $ss);

--- a/library/tiqr/tests/Tiqr_StateStorageTest.php
+++ b/library/tiqr/tests/Tiqr_StateStorageTest.php
@@ -1,0 +1,117 @@
+<?php
+
+require_once 'tiqr_autoloader.inc';
+
+use PHPUnit\Framework\TestCase;
+
+class Tiqr_StateStorageTest extends TestCase
+{
+    private function makeTempDir() {
+        $t=tempnam(sys_get_temp_dir(),'Tiqr_StateStorageTest');
+        unlink($t);
+        mkdir($t);
+        return $t;
+    }
+
+    function testCreateStateStorage() {
+        // Invalid type
+        $this->expectException(Exception::class);
+        Tiqr_StateStorage::getStorage("nonexistent", array());
+        $this->expectException(Exception::class);
+    }
+
+    function testStateStorage_File() {
+        // No config, always writes to /tmp
+        $ss=Tiqr_StateStorage::getStorage("file", array());
+        $this->assertInstanceOf(Tiqr_StateStorage_File::class, $ss);
+
+        $this->stateTests($ss);
+    }
+
+    function testStateStorage_Pdo() {
+        $tmpDir = $this->makeTempDir();
+        $dsn = 'sqlite:' . $tmpDir . '/state.sq3';
+        // Create test database
+        $pdo = new PDO(
+            $dsn,
+            null,
+            null,
+            array(\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,)
+        );
+        $this->assertTrue(
+            0 === $pdo->exec( <<<SQL
+                CREATE TABLE state (
+                    key varchar(255) PRIMARY KEY,
+                    expire int,
+                    value text
+                );
+SQL
+            ) );
+        $options=array(
+            'table' => 'state',
+            'dsn' => $dsn,
+            'username' => null,
+            'password' => null,
+        );
+        $ss=Tiqr_StateStorage::getStorage("pdo", $options);
+        $this->assertInstanceOf(Tiqr_StateStorage_Pdo::class, $ss);
+
+        $this->stateTests($ss);
+    }
+
+    private function stateTests(Tiqr_StateStorage_Abstract $ss) {
+        $ss->unsetValue("nonexistent_key");
+
+        // Gettng nonexistent value returns NULL
+        $this->assertEquals(NULL,  $ss->getValue("nonexistent_key"));
+
+        // Empty key allowed in Pdo and File, but Pdo fails silently
+        $this->assertEquals('', $ss->setValue('', 'empty', 0));
+        // Test it was written
+        if ($ss instanceof Tiqr_StateStorage_File) {
+            $this->assertEquals('empty', $ss->getValue(''));
+        }
+        elseif ($ss instanceof Tiqr_StateStorage_Pdo) {
+            $this->assertEquals(NULL, $ss->getValue(''));   // PDO won't return empty key
+        }
+        else {
+            throw new LogicException("Don't know how to test this type");
+        }
+
+        // Test update
+        $ss->setValue('update_key', 'first-value', 2);
+        $this->assertEquals('first-value', $ss->getValue('update_key'));  // Must exist
+        $ss->setValue('update_key', 'second-value', 0);    // Update all fields
+
+        // Test unsset
+        $ss->setValue('set-key-1', 'set-value-1', 0);
+        $this->assertEquals('set-value-1', $ss->getValue('set-key-1'));  // Must exist
+        $ss->setValue('set-key-2', 'set-value-2', 60);
+        $this->assertEquals('set-value-2', $ss->getValue('set-key-2'));  // Must exist
+        $ss->unsetValue('set-key-1');
+        $ss->unsetValue('set-key-2');
+        $this->assertEquals(NULL, $ss->getValue('set-key-1'));  // Must not xist
+        $this->assertEquals(NULL, $ss->getValue('set-key-2'));  // Must not xist
+
+        // Test expiry
+        $ss->setValue('long-expiry-key', 'long-expiry-value', 60 * 5);  // Expiry in 5 minutes
+        $this->assertEquals('long-expiry-value', $ss->getValue('long-expiry-key'));  // Must exist
+        $short_expiry_time=2;
+        $endtime = time() + $short_expiry_time + 1;
+        $ss->setValue('two-second-expiry-key', 'key_value-2', $short_expiry_time);  // Expiry in seconds
+        $this->assertEquals('key_value-2', $ss->getValue('two-second-expiry-key'));  // Must still exist
+
+        $count = 0;
+        while (time() < $endtime) {
+            $ss->getValue('two-second-expiry-key'); // Likely to trigger GC, depending on loop count
+            $count++;
+        }
+
+        $this->assertEquals(NULL, $ss->getValue('two-second-expiry-key'));  // Must not exist
+
+
+        // Check that keys with longer expiry still exist
+        $this->assertEquals('long-expiry-value', $ss->getValue('long-expiry-key'));  // Must still exist
+        $this->assertEquals('second-value', $ss->getValue('update_key'));  // Must still exist because we set it to never expire
+    }
+}


### PR DESCRIPTION
Strictly adhere to the expiry when using the pdo state storage. This brings the behavior in line with the of the memcache implementation and this means that the frequency at which the GC runs can be much, much lower.

Todo:
- Move GC run (cleanExpired) to setValue(). This will make the number of times that the GC runs more predictable
- Make the probability that the GC runs configurable

**Edit Michiel**: 
I opened this PR based on your work: #25 merging that into this branch should get us another step in the right direction.