### PR TITLE
Fix OCRA algorithm used by tiqr "v2" calculating incorrect responses …

### DIFF
--- a/library/tiqr/Tiqr/OATH/OCRA.php
+++ b/library/tiqr/Tiqr/OATH/OCRA.php
@@ -250,7 +250,12 @@ class OCRA {
     }
 
     /**
-     * Truncate a result to a certain length
+     * Implementation of the Truncate function from RFC4226
+     * Truncate a hex encoded (hash) result to a string of digital digits of $length
+     *
+     * @param string $hash hex encoded (hash) value to truncate. Minimum length is 20 bytes (i.e. a string of 40 hex digits)
+     * @param int $length number of decimal digits to truncate to
+     * @return string of $length digits
      */    
     static function _oath_truncate($hash, $length = 6)
     {
@@ -268,8 +273,11 @@ class OCRA {
             (($hmac_result[$offset+1] & 0xff) << 16 ) |
             (($hmac_result[$offset+2] & 0xff) << 8 ) |
             ($hmac_result[$offset+3] & 0xff)
-        );	
-        
+        );
+
+        // Prefix truncated string with 0's to ensure it always has the required length
+        $v=str_pad($v, $length, "0", STR_PAD_LEFT);
+
         $v = substr($v, strlen($v) - $length);
         return $v;
     }

--- a/library/tiqr/tests/OcraTest.php
+++ b/library/tiqr/tests/OcraTest.php
@@ -65,4 +65,38 @@ class ArrayTest extends TestCase
         $this->assertEquals("675831", $result);
     }
 
+    public function testTruncate() {
+        // Test RFC4226 truncate algorithm
+        // Use SHA-1 with an integer value to generate the strings to truncate
+        $tests=array(
+//          sha => expected result
+            6 => 37787,
+            23 => 24262,
+            114 => 5582,
+            203 => 3164,
+            480 => 385,
+            1784 => 313,
+            5001 => 65,
+            8012 => 12,
+            9536 => 41702,
+            22264 => 16058,
+            35619 => 3,
+            71453 => 5,
+            50979 => 16854,
+            68359 => 54266,
+            113274 => 7068,
+        );
+        foreach ($tests as $i => $expected) {
+            $hash=sha1($i);
+            $t=OCRA::_oath_truncate($hash, 6);
+            $this->assertIsString($t);
+            $this->assertTrue(strlen($t) == 6);
+
+            $this->assertEquals( $expected, (int)$t, "$i : $hash : t=$t");
+        }
+
+        // String consisting of "0000...000" must result in 0
+        $this->assertEquals( 0, (int)OCRA::_oath_truncate(str_repeat("00", 20), 6) );
+    }
+
 }

--- a/library/tiqr/tests/Tiqr_OCRAWrapperTest.php
+++ b/library/tiqr/tests/Tiqr_OCRAWrapperTest.php
@@ -92,14 +92,14 @@ class Tiqr_OCRAWrapperTest extends TestCase
             $v1_length[strlen($response1)]++;
             $response2 = $ocra2->calculateResponse($secret, $challenge, $session_key);
             $v2_length[strlen($response2)]++;
-            if ( str_pad($response1, 6, "0", STR_PAD_LEFT) != str_pad($response2, 10, "0", STR_PAD_LEFT) ) {
+            if ( (int)$response1 != (int)$response2 ) {
                 $v1_v2_mismatch++;
                 echo "v1: $response1 != v2: $response2\n";
                 echo "SECRET=$secret  Q=$challenge  S=$session_key\n";
             }
         }
-        // Average is 4 per 100000, fail when it is more than 3 times as high
-        $max_mismatch = (((float)$nr_tests) / 100000.0) * 4 * 3;
+        // With truncate bug fixed, there must be no more mismatches
+        $max_mismatch = 0;
         echo "Max allowed mismatches=$max_mismatch\n";
         $this->assertTrue($v1_v2_mismatch <= $max_mismatch, "Found $v1_v2_mismatch per $nr_tests. That is more than $max_mismatch");
 


### PR DESCRIPTION
…for some values

And add and update tests

Now both the old (v1) and the new (v2) algorithm generate the same response when interpreted as an integer for the default OCRA algorithm that is used by Tiqr. v1 and v2 responses may differ in string length because the v1 algorithm does not add leading "0"'s