### PR TITLE
Replace custom random generation with PHP random_bytes()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "kairos/phpqrcode": "~1.0",
         "ext-gd": "*",
         "ext-curl": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "php": ">=7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/library/tiqr/OATH/OCRAParser.php
+++ b/library/tiqr/OATH/OCRAParser.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once ( __DIR__ . "/../Tiqr/Random.php");
+
 class OATH_OCRAParser {
 
 	private $key = NULL;
@@ -179,7 +181,7 @@ class OATH_OCRAParser {
 		$q_length = $this->QLength;
 		$q_type = $this->QType;
 
-		$bytes = self::generateRandomBytes($q_length);
+        $bytes = Tiqr_Random::randomBytes($q_length);
 
 		switch($q_type) {
 			case 'A':
@@ -210,7 +212,7 @@ class OATH_OCRAParser {
 		}
 
 		$s_length = $this->SLength;
-		$bytes = self::generateRandomBytes($s_length);
+        $bytes = Tiqr_Random::randomBytes($s_length);
 
 		// The OCRA spec doesn't specify that the session data should be hexadecimal.
 		// However the reference implementation in the RFC does treat it as hex.
@@ -219,60 +221,6 @@ class OATH_OCRAParser {
 		$session = substr($session, 0, $s_length);
 		
 		return $session;
-	}
-
-	/**
-	 * Borrowed from SimpleSAMLPHP http://simplesamlphp.org/
-	 */
-	public static function generateRandomBytesMTrand($length) {
-
-		/* Use mt_rand to generate $length random bytes. */
-		$data = '';
-		for($i = 0; $i < $length; $i++) {
-			$data .= chr(mt_rand(0, 255));
-		}
-
-		return $data;
-	}
-
-
-	/**
-	 * Borrowed from SimpleSAMLPHP http://simplesamlphp.org/
-	 */
-	public static function generateRandomBytes($length, $fallback = TRUE) {
-		static $fp = NULL;
-
-		if (function_exists('openssl_random_pseudo_bytes')) {
-			return openssl_random_pseudo_bytes($length);
-		}
-
-		if($fp === NULL) {
-			if (@file_exists('/dev/urandom')) {
-				$fp = @fopen('/dev/urandom', 'rb');
-			} else {
-				$fp = FALSE;
-			}
-		}
-
-		if($fp !== FALSE) {
-			/* Read random bytes from /dev/urandom. */
-			$data = fread($fp, $length);
-			if($data === FALSE) {
-				throw new Exception('Error reading random data.');
-			}
-			if(strlen($data) != $length) {
-				if ($fallback) {
-					$data = self::generateRandomBytesMTrand($length);
-				} else {
-					throw new Exception('Did not get requested number of bytes from random source. Requested (' . $length . ') got (' . strlen($data) . ')');
-				}
-			}
-		} else {
-			/* Use mt_rand to generate $length random bytes. */
-			$data = self::generateRandomBytesMTrand($length);
-		}
-
-		return $data;
 	}
 
 

--- a/library/tiqr/Tiqr/OATH/OCRAWrapper_v1.php
+++ b/library/tiqr/Tiqr/OATH/OCRAWrapper_v1.php
@@ -63,7 +63,8 @@ class Tiqr_OCRAWrapper_v1
      */
     public function generateSessionKey() 
     {
-        return Tiqr_Random::randomHexString(self::SESSIONKEY_SIZE);
+        // TODO: Handle exception
+        return bin2hex( Tiqr_Random::randomBytes(self::SESSIONKEY_SIZE) );
     }
     
     /**

--- a/library/tiqr/Tiqr/OATH/OCRAWrapper_v1.php
+++ b/library/tiqr/Tiqr/OATH/OCRAWrapper_v1.php
@@ -63,7 +63,6 @@ class Tiqr_OCRAWrapper_v1
      */
     public function generateSessionKey() 
     {
-        // TODO: Handle exception
         return bin2hex( Tiqr_Random::randomBytes(self::SESSIONKEY_SIZE) );
     }
     

--- a/library/tiqr/Tiqr/Random.php
+++ b/library/tiqr/Tiqr/Random.php
@@ -41,7 +41,7 @@ class Tiqr_Random
         // Get $length cryptographically secure pseudo-random bytes
         $rnd=\random_bytes($length);
 
-        if (strlen($rnd) != $length) {
+        if (strlen($rnd) !== $length) {
             throw new Exception("random_bytes did not return the requested number of bytes");
         }
 

--- a/library/tiqr/Tiqr/Random.php
+++ b/library/tiqr/Tiqr/Random.php
@@ -21,51 +21,31 @@
 
 /**
  * A class implementing secure random number generation.
- * If openssl functionality is available, openssl is used to generate 
- * secure random data, if not, a twisted sha1 hash of a random number is used.
- * 
+ *
  * @author ivo
  *
  */
 class Tiqr_Random
 {
     /**
-     * Generate $length random bytes.
-     * 
-     * Code courtesy of http://www.zimuel.it/blog/2011/01/strong-cryptography-in-php/
-     * 
+     * Generate $length cryptographically secure pseudo-random bytes
+     * Throws when requested number of bytes cannot be generated
+     *
      * @param int $length the number of bytes to generate.
+     * @return string containing $length cryptographically secure pseudo-random bytes
+     *
+     * @throws Exception, Error, TypeError
      */
     public static function randomBytes($length)
     {
-       if(function_exists('openssl_random_pseudo_bytes')) {
-            $rnd = openssl_random_pseudo_bytes($length, $strong);
-            if($strong === TRUE && $rnd !== FALSE) {
-                return $rnd;
-            }
+        // Get $length cryptographically secure pseudo-random bytes
+        $rnd=\random_bytes($length);
+
+        if (strlen($rnd) != $length) {
+            throw new Exception("random_bytes did not return the requested number of bytes");
         }
 
-        // When openssl_random_pseudo_bytes failed, fall back on a mt_rand based string.
-
-        $rnd='';
-        
-        for ($i=0;$i<$length;$i++) {
-            $sha= sha1(mt_rand());
-            $char= mt_rand(0,30);
-            $rnd.= chr(hexdec($sha[$char].$sha[$char+1]));
-        }
-        
         return $rnd;
-     
     }
-    
-    /**
-     * Generate a random hex string of a certain length.
-     * @param int $length the desired length of the string
-     */
-    public static function randomHexString($length)
-    {
-         $result = bin2hex(self::randomBytes($length));
-         return $result;
-    }
+
 }

--- a/library/tiqr/tests/Tiqr_ServiceTest.php
+++ b/library/tiqr/tests/Tiqr_ServiceTest.php
@@ -65,6 +65,7 @@ class Tiqr_ServiceTest extends TestCase
         $enrollment_key = $service->startEnrollmentSession('test_user_id', 'Test User Name', $session_id);
         $this->assertIsString($enrollment_key);
         $this->assertRegExp('/^([0-9a-z][0-9a-z])+$/', $enrollment_key);
+        $this->assertEquals(64, strlen($enrollment_key));
 
         $status = $service->getEnrollmentStatus($session_id);
         $this->assertSame($status, Tiqr_Service::ENROLLMENT_STATUS_INITIALIZED);
@@ -92,6 +93,9 @@ class Tiqr_ServiceTest extends TestCase
         // 3a - We need to generate an enrollment URL, this must contain the enrollment secret
         // So we need to generate this enrollment secret first
         $enrollment_secret = $service->getEnrollmentSecret($enrollment_key);
+        $this->assertRegExp('/^([0-9a-z][0-9a-z])+$/', $enrollment_secret);
+        $this->assertEquals(64, strlen($enrollment_secret));
+
 
         $status = $service->getEnrollmentStatus($session_id);
         $this->assertSame($status, Tiqr_Service::ENROLLMENT_STATUS_INITIALIZED);    // Status remains unchanged
@@ -139,7 +143,8 @@ class Tiqr_ServiceTest extends TestCase
         // For the login scenario, where the server does not know the userid yet userid is left blank
         $session_key = $service->startAuthenticationSession($userid, $session_id );
         $this->assertIsString($session_key);
-        $this->assertNotEmpty($session_key);
+        $this->assertRegExp('/^([0-9a-z][0-9a-z])+$/', $session_key);
+        $this->assertEquals(64, strlen($session_key));
         $this->assertEquals(NULL, $service->getAuthenticatedUser($session_id));
 
         // Generate auth URL for in QR code


### PR DESCRIPTION
Replace custom random number generation code with one implementation that uses random_bytes()
Require PHP >= 7.0 for random_bytes()
random_bytes() uses getrandom() on linux

Note: Although unlikely random_bytes() can throw, which means that tiqr-server-libphp functions that previously did not throw can now thow an exception. I think this is better than e.g. the silent fallback to the non cryptogrphically secure mt_rand()