### PR TITLE
Move expiry action and make probability of triggering it configurable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "ext-pdo_sqlite": "*"
+        "ext-pdo_sqlite": "*",
+        "mockery/mockery": "^1.3"
     }
 }

--- a/library/tiqr/Tiqr/StateStorage.php
+++ b/library/tiqr/Tiqr/StateStorage.php
@@ -71,9 +71,9 @@ class Tiqr_StateStorage
 
                 $pdoInstance = new PDO($options['dsn'],$options['username'],$options['password']);
                 // Set a hard-coded default for the probability the expired state is removed
-                // 10 translates to: expired entries are removed 10 in every 1000 write actions
-                $cleanupProbability = 10;
-                if (array_key_exists('cleanup_probability', $options) && is_int($options['cleanup_probability'])) {
+                // 0.1 translates to a 10% chance the garbage collection is executed
+                $cleanupProbability = 0.1;
+                if (array_key_exists('cleanup_probability', $options) && is_numeric($options['cleanup_probability'])) {
                     $cleanupProbability = $options['cleanup_probability'];
                 }
 

--- a/library/tiqr/Tiqr/StateStorage/Pdo.php
+++ b/library/tiqr/Tiqr/StateStorage/Pdo.php
@@ -41,10 +41,15 @@ class Tiqr_StateStorage_Pdo extends Tiqr_StateStorage_Abstract
      */
     private $cleanupProbability;
 
-    public function __construct(PDO $pdoInstance, string $tablename, int $cleanupProbability)
+    /**
+     * @param PDO $pdoInstance The PDO instance where all state storage operations are performed on
+     * @param string $tablename The tablename that is used for storing and retrieving the state storage
+     * @param int $cleanupProbability The probability the expired state storage items are removed on a 'setValue' call. Example usage: 0 = never, 0.5 = 50% chance, 1 = always
+     */
+    public function __construct(PDO $pdoInstance, string $tablename, float $cleanupProbability)
     {
-        if ($cleanupProbability < 1 || $cleanupProbability > 1000) {
-            throw new RuntimeException('The probability for removing the expired state should be expressed in a value between 1 and 1000.');
+        if ($cleanupProbability < 0 || $cleanupProbability > 1) {
+            throw new RuntimeException('The probability for removing the expired state should be expressed in a floating point value between 0 and 1.');
         }
         $this->cleanupProbability = $cleanupProbability;
         $this->tablename = $tablename;
@@ -69,7 +74,7 @@ class Tiqr_StateStorage_Pdo extends Tiqr_StateStorage_Abstract
      */
     public function setValue($key, $value, $expire=0)
     {
-        if (rand(0, 1000) < $this->cleanupProbability) {
+        if (((float) rand() /(float) getrandmax()) < $this->cleanupProbability) {
             $this->cleanExpired();
         }
         if ($this->keyExists($key)) {

--- a/library/tiqr/tests/Tiqr_StateStoragePdoTest.php
+++ b/library/tiqr/tests/Tiqr_StateStoragePdoTest.php
@@ -40,7 +40,7 @@ class Tiqr_StateStoragePdoTest extends TestCase
 
         $pdoInstance = new PDO($dsn, null, null);
         $this->pdoInstance = m::mock($pdoInstance);
-        $this->stateStorage = new Tiqr_StateStorage_Pdo($this->pdoInstance, 'state', 1000);
+        $this->stateStorage = new Tiqr_StateStorage_Pdo($this->pdoInstance, 'state', 1);
         $this->assertInstanceOf(Tiqr_StateStorage_Pdo::class, $this->stateStorage);
     }
 
@@ -77,17 +77,15 @@ class Tiqr_StateStoragePdoTest extends TestCase
     public function test_input_validation_for_cleanup_probability($incorrectValue)
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The probability for removing the expired state should be expressed in a value between 1 and 1000.');
+        $this->expectExceptionMessage('The probability for removing the expired state should be expressed in a floating point value between 0 and 1.');
         new Tiqr_StateStorage_Pdo(m::mock(PDO::class), 'tablename', $incorrectValue);
     }
 
     public function provideIncorrectCleanupProbabilityValues()
     {
         return [
-            'value too low' => [0],
-            'value too below zero' => [-1],
-            'value too high' => [1001],
-            'value too high close to overflow point' => [9223372036854775807],
+            'value too low' => [-1],
+            'value too high' => [1.001],
         ];
     }
 }

--- a/library/tiqr/tests/Tiqr_StateStoragePdoTest.php
+++ b/library/tiqr/tests/Tiqr_StateStoragePdoTest.php
@@ -1,0 +1,93 @@
+<?php
+
+require_once 'tiqr_autoloader.inc';
+
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class Tiqr_StateStoragePdoTest extends TestCase
+{
+    /**
+     * @var Tiqr_StateStorage_Pdo
+     */
+    private $stateStorage;
+
+    /**
+     * @var MockInterface|PDO
+     */
+    private $pdoInstance;
+
+    private function makeTempDir() {
+        $tempName = tempnam(sys_get_temp_dir(),'Tiqr_StateStorageTest');
+        unlink($tempName);
+        mkdir($tempName);
+        return $tempName;
+    }
+
+    private function setUpDatabase(string $dsn)
+    {
+        // Create test database
+        $pdo = new PDO($dsn, null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $pdo->exec("CREATE TABLE state (key varchar(255) PRIMARY KEY, expire int, value text);");
+    }
+
+    protected function setUp(): void
+    {
+        $targetPath = $this->makeTempDir();
+        $dsn = 'sqlite:' . $targetPath . '/state.sq3';
+        $this->setUpDatabase($dsn);
+
+        $pdoInstance = new PDO($dsn, null, null);
+        $this->pdoInstance = m::mock($pdoInstance);
+        $this->stateStorage = new Tiqr_StateStorage_Pdo($this->pdoInstance, 'state', 1000);
+        $this->assertInstanceOf(Tiqr_StateStorage_Pdo::class, $this->stateStorage);
+    }
+
+    function test_called_clean_expired() {
+        // Here be dragons: first call to the PDO's prepare statement must be a DELETE query
+        // (clearing the expired entries)
+        $this->pdoInstance
+            ->shouldReceive('prepare')
+            ->once()
+            ->withArgs(function($query) {
+                $queryType = substr($query, 0,6);
+                // This assertion focusses on the Delete statement, let the others through without checking
+                if ($queryType === 'DELETE') {
+                    $this->assertStringContainsString('DELETE FROM state', $query);
+                    $this->assertStringContainsString('WHERE `expire` < ? AND NOT `expire` = 0', $query);
+                    return true;
+                }
+                $this->fail('The first call to the prepare PDO method should be with a DELETE statement');
+            })->andReturn(m::mock(PDOStatement::class)->shouldIgnoreMissing());
+        // The other prepare statements we don't care about, but they must be
+        // declared to prevent expectation errors. Covering them in the expectation above
+        // raises side effects, as it becomes impossible to tell in what order the prepare
+        // statement is called.
+        $this->pdoInstance
+            ->shouldReceive('prepare')
+            ->andReturn(m::mock(PDOStatement::class)->shouldIgnoreMissing());
+
+        $this->stateStorage->setValue('key', 'data', 1);
+    }
+
+    /**
+     * @dataProvider provideIncorrectCleanupProbabilityValues
+     */
+    public function test_input_validation_for_cleanup_probability($incorrectValue)
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The probability for removing the expired state should be expressed in a value between 1 and 1000.');
+        new Tiqr_StateStorage_Pdo(m::mock(PDO::class), 'tablename', $incorrectValue);
+    }
+
+    public function provideIncorrectCleanupProbabilityValues()
+    {
+        return [
+            'value too low' => [0],
+            'value too below zero' => [-1],
+            'value too high' => [1001],
+            'value too high close to overflow point' => [9223372036854775807],
+        ];
+    }
+}

--- a/library/tiqr/tests/Tiqr_StateStorageTest.php
+++ b/library/tiqr/tests/Tiqr_StateStorageTest.php
@@ -52,6 +52,7 @@ SQL
             'dsn' => $dsn,
             'username' => null,
             'password' => null,
+            'cleanup_probability' => 0.6
         );
         $ss=Tiqr_StateStorage::getStorage("pdo", $options);
         $this->assertInstanceOf(Tiqr_StateStorage_Pdo::class, $ss);


### PR DESCRIPTION
The State Storage PDO implementation was extended with a new configuration option, making it possible to set the probability the expired state storage is cleaned up.

And the expiry action was moved from the getValue method (called often) to the setValue method (called less often).

An effort was taken to improve test coverage. And at least cover the new features in test. @pmeulen already provided test coverage for the Factory tasked with creating the PDO state storage instance.

https://www.pivotaltracker.com/story/show/181553917