### PR TITLE
Run local-php-security-checker on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ install:
 
 script:
   - vendor/bin/phpunit
+  - wget -q https://github.com/fabpot/local-php-security-checker/releases/download/v1.0.0/local-php-security-checker_1.0.0_linux_amd64 -O local-php-security-checker && chmod +x ./local-php-security-checker && ./local-php-security-checker


### PR DESCRIPTION
Having security tests might prove helpful in staying on top of security issues. And will remind us on a more frequent basis to get rid of very old dependencies.

Disclaimer, this task is not on the backlog: added this under the boy-scout-rule :deciduous_tree: 