### PR TITLE
Improve StateStorage File implementation

### DIFF
--- a/library/tiqr/Tiqr/AutoLoader.php
+++ b/library/tiqr/Tiqr/AutoLoader.php
@@ -37,6 +37,8 @@ class Tiqr_AutoLoader {
 			$file = $self->qrcodePath . DIRECTORY_SEPARATOR . 'qrlib.php';
 		} elseif ($substr5 === 'Zend_') {
 			$file = $self->zendPath . DIRECTORY_SEPARATOR . str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
+        } elseif ($className === 'ReadWriteException') {
+            $file = $self->tiqrPath . DIRECTORY_SEPARATOR . 'Tiqr/Exception/ReadWriteException.php';
 		} else {
 			return;
 		}

--- a/library/tiqr/Tiqr/Exception/ReadWriteException.php
+++ b/library/tiqr/Tiqr/Exception/ReadWriteException.php
@@ -16,6 +16,6 @@
  * limitations under the License.
  */
 
-class Tiqr_Exception_ReadWriteException extends RuntimeException
+class ReadWriteException extends RuntimeException
 {
 }

--- a/library/tiqr/Tiqr/Exception/ReadWriteException.php
+++ b/library/tiqr/Tiqr/Exception/ReadWriteException.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Copyright 2022 SURF B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class Tiqr_Exception_ReadWriteException extends RuntimeException
+{
+}

--- a/library/tiqr/Tiqr/Service.php
+++ b/library/tiqr/Tiqr/Service.php
@@ -201,9 +201,7 @@ class Tiqr_Service
             $type = $options["statestorage"]["type"];
             $storageOptions = $options["statestorage"];
         } else {
-            $this->logger->info('Falling back to file state storage');
-            $type = "file";
-            $storageOptions = array();
+            throw new RuntimeException('No state storage configuration is configured, please provide one');
         }
 
         $this->logger->info(sprintf('Creating a %s state storage', $type));

--- a/library/tiqr/Tiqr/StateStorage.php
+++ b/library/tiqr/Tiqr/StateStorage.php
@@ -52,7 +52,10 @@ class Tiqr_StateStorage
         switch ($type) {
             case "file":
                 require_once("Tiqr/StateStorage/File.php");
-                $instance = new Tiqr_StateStorage_File($options, $logger);
+                if (!array_key_exists('path', $options)) {
+                    throw new RuntimeException('The path is missing in the StateStorage configuration');
+                }
+                $instance = new Tiqr_StateStorage_File($options['path'], $logger);
                 $instance->init();
                 return $instance;
             case "memcache":

--- a/library/tiqr/Tiqr/StateStorage/Abstract.php
+++ b/library/tiqr/Tiqr/StateStorage/Abstract.php
@@ -27,7 +27,7 @@ use Psr\Log\LoggerInterface;
  * @author ivo
  *
  */
-abstract class Tiqr_StateStorage_Abstract
+abstract class Tiqr_StateStorage_Abstract implements Tiqr_StateStorage_StateStorageInterface
 {
     /**
      * The options for the storage. Derived classes can access this
@@ -41,27 +41,6 @@ abstract class Tiqr_StateStorage_Abstract
      */
     protected $logger;
 
-    /**
-     * Store a value with a certain key in the statestorage.
-     * @param String $key The key identifying the data
-     * @param mixed $value The data to store in state storage
-     * @param int $expire The expiration (in seconds) of the data
-     */
-    public abstract function setValue($key, $value, $expire=0);
-    
-    /**
-     * Remove a value from the state storage
-     * @param String $key The key identifying the data to be removed.
-     */
-    public abstract function unsetValue($key);
-    
-    /**
-     * Retrieve the data for a certain key.
-     * @param String $key The key identifying the data to be retrieved.
-     * @return mixed The data associated with the key
-     */
-    public abstract function getValue($key);
-    
     /**
      * An initializer that will be called directly after instantiating
      * the storage. Derived classes can override this to perform 
@@ -84,7 +63,6 @@ abstract class Tiqr_StateStorage_Abstract
     public function __construct($options=array(), LoggerInterface $logger)
     {
         $this->logger = $logger;
-        $this->_options = $options;        
+        $this->_options = $options;
     }
-        
 }

--- a/library/tiqr/Tiqr/StateStorage/File.php
+++ b/library/tiqr/Tiqr/StateStorage/File.php
@@ -44,10 +44,6 @@ class Tiqr_StateStorage_File implements Tiqr_StateStorage_StateStorageInterface
         $this->path = $path;
     }
 
-    /**
-     * (non-PHPdoc)
-     * @see library/tiqr/Tiqr/StateStorage/Tiqr_StateStorage_Abstract::setValue()
-     */
     public function setValue($key, $value, $expire=0)
     {   
         $envelope = array("expire"=>$expire,
@@ -56,7 +52,7 @@ class Tiqr_StateStorage_File implements Tiqr_StateStorage_StateStorageInterface
         $filename = $this->getFilenameByKey($key);
         
         if (!file_put_contents($filename, serialize($envelope))) {
-            $this->logger->error('Unable to write the value to state storage');
+            throw new ReadWriteException(sprintf('Unable to store "%s" state to the filesystem', $key));
         }
         
         return $key;
@@ -69,10 +65,13 @@ class Tiqr_StateStorage_File implements Tiqr_StateStorage_StateStorageInterface
     public function unsetValue($key)
     {
         $filename = $this->getFilenameByKey($key);
-        if (file_exists($filename)) {
-            unlink($filename);
-        } else {
-            $this->logger->error('Unable to unlink the value from state storage, key not found on filesystem');
+        if (file_exists($filename) & !unlink($filename)) {
+            throw new ReadWriteException(
+                sprintf(
+                    'Unable to unlink the "%s" value from state storage on filesystem',
+                    $key
+                )
+            );
         }
     }
     

--- a/library/tiqr/Tiqr/StateStorage/File.php
+++ b/library/tiqr/Tiqr/StateStorage/File.php
@@ -17,6 +17,8 @@
  * @copyright (C) 2010-2011 SURFnet BV
  */
 
+use Psr\Log\LoggerInterface;
+
 
 /**
  * File based implementation to store session state data. 
@@ -30,8 +32,18 @@
  * @author ivo
  *
  */
-class Tiqr_StateStorage_File extends Tiqr_StateStorage_Abstract
+class Tiqr_StateStorage_File implements Tiqr_StateStorage_StateStorageInterface
 {
+    private $logger;
+
+    private $path;
+
+    public function __construct(string $path, LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+        $this->path = $path;
+    }
+
     /**
      * (non-PHPdoc)
      * @see library/tiqr/Tiqr/StateStorage/Tiqr_StateStorage_Abstract::setValue()
@@ -41,9 +53,11 @@ class Tiqr_StateStorage_File extends Tiqr_StateStorage_Abstract
         $envelope = array("expire"=>$expire,
                           "createdAt"=>time(),
                           "value"=>$value);
-        $filename = $this->_stateFilename($key);
+        $filename = $this->getFilenameByKey($key);
         
-        file_put_contents($filename, serialize($envelope));
+        if (!file_put_contents($filename, serialize($envelope))) {
+            $this->logger->error('Unable to write the value to state storage');
+        }
         
         return $key;
     }
@@ -54,7 +68,7 @@ class Tiqr_StateStorage_File extends Tiqr_StateStorage_Abstract
      */
     public function unsetValue($key)
     {
-        $filename = $this->_stateFilename($key);
+        $filename = $this->getFilenameByKey($key);
         if (file_exists($filename)) {
             unlink($filename);
         } else {
@@ -68,30 +82,43 @@ class Tiqr_StateStorage_File extends Tiqr_StateStorage_Abstract
      */
     public function getValue($key)
     {
-        $filename = $this->_stateFilename($key);
+        $filename = $this->getFilenameByKey($key);
         if (file_exists($filename)) {
-            $envelope = unserialize(file_get_contents($filename));
-            if ($envelope["expire"]!=0) {
-                 // This data is time-limited. If it's too old we discard it.
-                 if (time()-$envelope["createdAt"] > $envelope["expire"]) {
-                     $this->unsetValue($key);
-                     $this->logger->error('Unable to retrieve the state storage value, it is expired');
-                     return NULL;
-                 }
+            $envelope = unserialize(file_get_contents($filename), ['allowed_classes' => false]);
+            // This data is time-limited. If it's too old we discard it.
+            if (($envelope["expire"] != 0) && time() - $envelope["createdAt"] > $envelope["expire"]) {
+                $this->unsetValue($key);
+                $this->logger->notice('Unable to retrieve the state storage value, it is expired');
+                return null;
             }
             return $envelope["value"];
         }
-        $this->logger->error('Unable to retrieve the state storage value, file not found');
+        $this->logger->notice('Unable to retrieve the state storage value, file not found');
         return NULL;
     }
-    
+
+    private function getPath(): string
+    {
+        if (substr($this->path, -1)!=="/") {
+            return $this->path . "/";
+        }
+        return $this->path;
+    }
+
     /**
      * Determine the name of a temporary file to hold the contents of $key
-     * @param String $key The key for which to store data.
      */
-    protected function _stateFilename($key)
+    private function getFilenameByKey(string $key): string
     {
-        return "/tmp/tiqr_state_".strtr(base64_encode($key), '+/', '-_');
+        return sprintf(
+            "%stiqr_state_%s",
+            $this->getPath(),
+            strtr(base64_encode($key), '+/', '-_')
+        );
     }
-    
+
+    public function init()
+    {
+        # Nothing to do here
+    }
 }

--- a/library/tiqr/Tiqr/StateStorage/File.php
+++ b/library/tiqr/Tiqr/StateStorage/File.php
@@ -65,7 +65,7 @@ class Tiqr_StateStorage_File implements Tiqr_StateStorage_StateStorageInterface
     public function unsetValue($key)
     {
         $filename = $this->getFilenameByKey($key);
-        if (file_exists($filename) & !unlink($filename)) {
+        if (file_exists($filename) && !unlink($filename)) {
             throw new ReadWriteException(
                 sprintf(
                     'Unable to unlink the "%s" value from state storage on filesystem',

--- a/library/tiqr/Tiqr/StateStorage/Memcache.php
+++ b/library/tiqr/Tiqr/StateStorage/Memcache.php
@@ -112,7 +112,7 @@ class Tiqr_StateStorage_Memcache extends Tiqr_StateStorage_Abstract
             $result = $this->_memcache->set($key, $value, 0, $expire);
         }
         if (!$result) {
-            throw new Tiqr_Exception_ReadWriteException(sprintf('Unable to store "%s" state to Memcache', $key));
+            throw new ReadWriteException(sprintf('Unable to store "%s" state to Memcache', $key));
         }
     }
     
@@ -125,7 +125,7 @@ class Tiqr_StateStorage_Memcache extends Tiqr_StateStorage_Abstract
         $key = $this->_getKeyPrefix().$key;
         $result = $this->_memcache->delete($key);
         if (!$result) {
-            throw new Tiqr_Exception_ReadWriteException(
+            throw new ReadWriteException(
                 sprintf(
                     'Unable to unlink the "%s" value from state storage, key not found in Memcache',
                     $key

--- a/library/tiqr/Tiqr/StateStorage/Memcache.php
+++ b/library/tiqr/Tiqr/StateStorage/Memcache.php
@@ -107,9 +107,12 @@ class Tiqr_StateStorage_Memcache extends Tiqr_StateStorage_Abstract
         $key = $this->_getKeyPrefix().$key;
 
         if (self::$extension === '\memcached') {
-            $this->_memcache->set($key, $value, $expire);
+            $result = $this->_memcache->set($key, $value, $expire);
         } else {
-            $this->_memcache->set($key, $value, 0, $expire);
+            $result = $this->_memcache->set($key, $value, 0, $expire);
+        }
+        if (!$result) {
+            throw new Tiqr_Exception_ReadWriteException(sprintf('Unable to store "%s" state to Memcache', $key));
         }
     }
     
@@ -120,8 +123,16 @@ class Tiqr_StateStorage_Memcache extends Tiqr_StateStorage_Abstract
     public function unsetValue($key)
     {
         $key = $this->_getKeyPrefix().$key;
-        
-        return $this->_memcache->delete($key);
+        $result = $this->_memcache->delete($key);
+        if (!$result) {
+            throw new Tiqr_Exception_ReadWriteException(
+                sprintf(
+                    'Unable to unlink the "%s" value from state storage, key not found in Memcache',
+                    $key
+                )
+            );
+        }
+        return $result;
     }
     
     /**

--- a/library/tiqr/Tiqr/StateStorage/StateStorageInterface.php
+++ b/library/tiqr/Tiqr/StateStorage/StateStorageInterface.php
@@ -22,14 +22,14 @@ interface Tiqr_StateStorage_StateStorageInterface
      * @param String $key The key identifying the data
      * @param mixed $value The data to store in state storage
      * @param int $expire The expiration (in seconds) of the data
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     public function setValue($key, $value, $expire=0);
 
     /**
      * Remove a value from the state storage
      * @param String $key The key identifying the data to be removed.
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     public function unsetValue($key);
 

--- a/library/tiqr/Tiqr/StateStorage/StateStorageInterface.php
+++ b/library/tiqr/Tiqr/StateStorage/StateStorageInterface.php
@@ -22,12 +22,14 @@ interface Tiqr_StateStorage_StateStorageInterface
      * @param String $key The key identifying the data
      * @param mixed $value The data to store in state storage
      * @param int $expire The expiration (in seconds) of the data
+     * @throws Tiqr_Exception_ReadWriteException
      */
     public function setValue($key, $value, $expire=0);
 
     /**
      * Remove a value from the state storage
      * @param String $key The key identifying the data to be removed.
+     * @throws Tiqr_Exception_ReadWriteException
      */
     public function unsetValue($key);
 

--- a/library/tiqr/Tiqr/StateStorage/StateStorageInterface.php
+++ b/library/tiqr/Tiqr/StateStorage/StateStorageInterface.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2022 SURF B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface Tiqr_StateStorage_StateStorageInterface
+{
+    /**
+     * Store a value with a certain key in the statestorage.
+     * @param String $key The key identifying the data
+     * @param mixed $value The data to store in state storage
+     * @param int $expire The expiration (in seconds) of the data
+     */
+    public function setValue($key, $value, $expire=0);
+
+    /**
+     * Remove a value from the state storage
+     * @param String $key The key identifying the data to be removed.
+     */
+    public function unsetValue($key);
+
+    /**
+     * Retrieve the data for a certain key.
+     * @param String $key The key identifying the data to be retrieved.
+     * @return mixed The data associated with the key
+     */
+    public function getValue($key);
+
+    /**
+     * Called to initialize the storage engine
+     * @return void
+     */
+    public function init();
+}

--- a/library/tiqr/Tiqr/UserSecretStorage.php
+++ b/library/tiqr/Tiqr/UserSecretStorage.php
@@ -73,8 +73,16 @@ class Tiqr_UserSecretStorage
                 $userName = $options['username'];
                 $password = $options['password'];
 
+                try {
+                    $handle = new PDO($dsn, $userName, $password);
+                } catch (PDOException $e) {
+                    $logger->error(
+                        sprintf('Unable to establish a PDO connection. Error message from PDO: %s', $e->getMessage())
+                    );
+                }
+
                 require_once("Tiqr/UserSecretStorage/Pdo.php");
-                return new Tiqr_UserSecretStorage_Pdo($encryption, $logger, $dsn, $userName, $password, $tableName);
+                return new Tiqr_UserSecretStorage_Pdo($encryption, $logger, $handle, $tableName);
             case "oathserviceclient":
                 require_once("Tiqr/UserSecretStorage/OathServiceClient.php");
                 if (!array_key_exists('apiURL', $options)) {

--- a/library/tiqr/Tiqr/UserSecretStorage/File.php
+++ b/library/tiqr/Tiqr/UserSecretStorage/File.php
@@ -65,7 +65,7 @@ class Tiqr_UserSecretStorage_File implements Tiqr_UserSecretStorage_Interface
                 return $data["secret"];
             }
         }
-        $this->logger->error('Unable to retrieve the secret (user not found). In user secret storage (file)');
+        $this->logger->notice('Unable to retrieve the secret (user not found). In user secret storage (file)');
         return NULL;
     }
 

--- a/library/tiqr/Tiqr/UserSecretStorage/Interface.php
+++ b/library/tiqr/Tiqr/UserSecretStorage/Interface.php
@@ -46,6 +46,7 @@ interface Tiqr_UserSecretStorage_Interface
      * Store a secret for a user.
      * @param String $userId
      * @param String $secret
+     * @throws Tiqr_Exception_ReadWriteException
      */
     public function setSecret($userId, $secret);
 }

--- a/library/tiqr/Tiqr/UserSecretStorage/Interface.php
+++ b/library/tiqr/Tiqr/UserSecretStorage/Interface.php
@@ -46,7 +46,7 @@ interface Tiqr_UserSecretStorage_Interface
      * Store a secret for a user.
      * @param String $userId
      * @param String $secret
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     public function setSecret($userId, $secret);
 }

--- a/library/tiqr/Tiqr/UserSecretStorage/Pdo.php
+++ b/library/tiqr/Tiqr/UserSecretStorage/Pdo.php
@@ -47,29 +47,18 @@ class Tiqr_UserSecretStorage_Pdo implements Tiqr_UserSecretStorage_Interface
     /**
      * @param Tiqr_UserSecretStorage_Encryption_Interface $encryption
      * @param LoggerInterface $logger
-     * @param string $dsn
-     * @param string $userName
-     * @param string $password
-     * @param string $tableName
+     * @param PDO $handle
      */
     public function __construct(
         Tiqr_UserSecretStorage_Encryption_Interface $encryption,
         LoggerInterface $logger,
-        string $dsn,
-        string $userName,
-        string $password,
-        string $tableName = 'tiqrusersecret'
+        PDO $handle,
+        string $tableName
     ) {
         $this->encryption = $encryption;
         $this->logger = $logger;
+        $this->handle = $handle;
         $this->tableName = $tableName;
-        try {
-            $this->handle = new PDO($dsn, $userName, $password);
-        } catch (PDOException $e) {
-            $this->logger->error(
-                sprintf('Unable to establish a PDO connection. Error message from PDO: %s', $e->getMessage())
-            );
-        }
     }
     private function userExists($userId)
     {
@@ -117,7 +106,7 @@ class Tiqr_UserSecretStorage_Pdo implements Tiqr_UserSecretStorage_Interface
         }
         $result = $sth->execute(array($secret,$userId));
         if (!$result) {
-            $this->logger->error('Unable to persist user secret in user secret storage (PDO)');
+            throw new Tiqr_Exception_ReadWriteException('Unable to persist user secret in user secret storage (PDO)');
         }
     }
 }

--- a/library/tiqr/Tiqr/UserSecretStorage/Pdo.php
+++ b/library/tiqr/Tiqr/UserSecretStorage/Pdo.php
@@ -99,7 +99,7 @@ class Tiqr_UserSecretStorage_Pdo implements Tiqr_UserSecretStorage_Interface
                 return $secret;
             }
         }
-        $this->logger->error('Unable to retrieve user secret from user secret storage (PDO)');
+        $this->logger->notice('Unable to retrieve user secret from user secret storage (PDO)');
     }
 
     /**

--- a/library/tiqr/Tiqr/UserSecretStorage/Pdo.php
+++ b/library/tiqr/Tiqr/UserSecretStorage/Pdo.php
@@ -106,7 +106,7 @@ class Tiqr_UserSecretStorage_Pdo implements Tiqr_UserSecretStorage_Interface
         }
         $result = $sth->execute(array($secret,$userId));
         if (!$result) {
-            throw new Tiqr_Exception_ReadWriteException('Unable to persist user secret in user secret storage (PDO)');
+            throw new ReadWriteException('Unable to persist user secret in user secret storage (PDO)');
         }
     }
 }

--- a/library/tiqr/Tiqr/UserStorage/File.php
+++ b/library/tiqr/Tiqr/UserStorage/File.php
@@ -45,18 +45,4 @@ class Tiqr_UserStorage_File extends Tiqr_UserStorage_GenericStore
         parent::__construct($config, $logger);
         $this->path = $config["path"];
     }
-
-    /**
-     * Delete user data (un-enroll).
-     * @param String $userId
-     */
-    protected function _deleteUser($userId)
-    {
-        $filename = $this->getPath().$userId.".json";
-        if (file_exists($filename)) {
-            unlink($filename);
-        } else {
-            $this->logger->error('Unable to remove the user from user storage (file storage)');
-        }
-    }
 }

--- a/library/tiqr/Tiqr/UserStorage/FileTrait.php
+++ b/library/tiqr/Tiqr/UserStorage/FileTrait.php
@@ -19,14 +19,14 @@ trait FileTrait
 {
     /**
      * This function takes care of actually saving the user data to a JSON file.
-     * @param String $userId
+     * @param string $userId
      * @param array $data
+     * @throws Tiqr_Exception_ReadWriteException
      */
     protected function _saveUser($userId, $data)
     {
         if (file_put_contents($this->getPath().$userId.".json", json_encode($data)) === false) {
-            $this->logger->error('Unable to save the user to user storage (file storage)');
-            return false;
+            throw new Tiqr_Exception_ReadWriteException('Unable to save the user to user storage (file storage)');
         }
         return true;
     }

--- a/library/tiqr/Tiqr/UserStorage/FileTrait.php
+++ b/library/tiqr/Tiqr/UserStorage/FileTrait.php
@@ -21,12 +21,12 @@ trait FileTrait
      * This function takes care of actually saving the user data to a JSON file.
      * @param string $userId
      * @param array $data
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     protected function _saveUser($userId, $data)
     {
         if (file_put_contents($this->getPath().$userId.".json", json_encode($data)) === false) {
-            throw new Tiqr_Exception_ReadWriteException('Unable to save the user to user storage (file storage)');
+            throw new ReadWriteException('Unable to save the user to user storage (file storage)');
         }
         return true;
     }

--- a/library/tiqr/Tiqr/UserStorage/FileTrait.php
+++ b/library/tiqr/Tiqr/UserStorage/FileTrait.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2022 SURF B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 trait FileTrait
 {
     /**

--- a/library/tiqr/Tiqr/UserStorage/GenericStore.php
+++ b/library/tiqr/Tiqr/UserStorage/GenericStore.php
@@ -33,8 +33,6 @@ abstract class Tiqr_UserStorage_GenericStore extends Tiqr_UserStorage_Abstract
   
     abstract protected function _saveUser($userId, $data);
 
-    abstract protected function _deleteUser($userId);
-
 
     /**
      * (non-PHPdoc)

--- a/library/tiqr/Tiqr/UserStorage/Interface.php
+++ b/library/tiqr/Tiqr/UserStorage/Interface.php
@@ -47,7 +47,7 @@ interface Tiqr_UserStorage_Interface
      * Store a new user with a certain displayName.
      * @param String $userId
      * @param String $displayName
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     public function createUser($userId, $displayName);
     
@@ -76,7 +76,7 @@ interface Tiqr_UserStorage_Interface
      * Set the notification type of a user.
      * @param String $userId
      * @param String $type
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     public function setNotificationType($userId, $type);
     
@@ -91,7 +91,7 @@ interface Tiqr_UserStorage_Interface
      * Set the notification address of a user's device
      * @param String $userId
      * @param String $address
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     public function setNotificationAddress($userId, $address);
     
@@ -104,7 +104,7 @@ interface Tiqr_UserStorage_Interface
      * Set the amount of unsuccessful login attempts.
      * @param String $userId
      * @param int $amount
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     public function setLoginAttempts($userId, $amount);
     
@@ -119,7 +119,7 @@ interface Tiqr_UserStorage_Interface
      * Block the user account.
      * @param $userId
      * @param $blocked true to block, false to unblock
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     public function setBlocked($userId, $blocked);
     
@@ -127,7 +127,7 @@ interface Tiqr_UserStorage_Interface
      * Set the number of times a temporary block was set during this session
      * @param string $userId
      * @param int $amount
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     public function setTemporaryBlockAttempts($userId, $amount);
     
@@ -141,7 +141,7 @@ interface Tiqr_UserStorage_Interface
      * Set the timestamp for the temporary block
      * @param string $userId
      * @param string $timestamp
-     * @throws Tiqr_Exception_ReadWriteException
+     * @throws ReadWriteException
      */
     public function setTemporaryBlockTimestamp($userId, $timestamp);
     

--- a/library/tiqr/Tiqr/UserStorage/Interface.php
+++ b/library/tiqr/Tiqr/UserStorage/Interface.php
@@ -47,6 +47,7 @@ interface Tiqr_UserStorage_Interface
      * Store a new user with a certain displayName.
      * @param String $userId
      * @param String $displayName
+     * @throws Tiqr_Exception_ReadWriteException
      */
     public function createUser($userId, $displayName);
     
@@ -75,6 +76,7 @@ interface Tiqr_UserStorage_Interface
      * Set the notification type of a user.
      * @param String $userId
      * @param String $type
+     * @throws Tiqr_Exception_ReadWriteException
      */
     public function setNotificationType($userId, $type);
     
@@ -89,6 +91,7 @@ interface Tiqr_UserStorage_Interface
      * Set the notification address of a user's device
      * @param String $userId
      * @param String $address
+     * @throws Tiqr_Exception_ReadWriteException
      */
     public function setNotificationAddress($userId, $address);
     
@@ -101,6 +104,7 @@ interface Tiqr_UserStorage_Interface
      * Set the amount of unsuccessful login attempts.
      * @param String $userId
      * @param int $amount
+     * @throws Tiqr_Exception_ReadWriteException
      */
     public function setLoginAttempts($userId, $amount);
     
@@ -115,6 +119,7 @@ interface Tiqr_UserStorage_Interface
      * Block the user account.
      * @param $userId
      * @param $blocked true to block, false to unblock
+     * @throws Tiqr_Exception_ReadWriteException
      */
     public function setBlocked($userId, $blocked);
     
@@ -122,6 +127,7 @@ interface Tiqr_UserStorage_Interface
      * Set the number of times a temporary block was set during this session
      * @param string $userId
      * @param int $amount
+     * @throws Tiqr_Exception_ReadWriteException
      */
     public function setTemporaryBlockAttempts($userId, $amount);
     
@@ -135,6 +141,7 @@ interface Tiqr_UserStorage_Interface
      * Set the timestamp for the temporary block
      * @param string $userId
      * @param string $timestamp
+     * @throws Tiqr_Exception_ReadWriteException
      */
     public function setTemporaryBlockTimestamp($userId, $timestamp);
     

--- a/library/tiqr/Tiqr/UserStorage/Pdo.php
+++ b/library/tiqr/Tiqr/UserStorage/Pdo.php
@@ -82,7 +82,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
             // TODO: this method should return a boolean value on all possible outcomes or throw an exception
             return $sth->fetchColumn();
         }
-        $this->logger->error('Unable to find user in user storage (PDO)');
+        $this->logger->notice('Unable to find user in user storage (PDO)');
     }
     
     public function getDisplayName($userId)
@@ -91,7 +91,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
         if ($sth->execute(array($userId))) {
             return $sth->fetchColumn();
         }
-        $this->logger->error('Retrieving the users display name failed in the user storage (PDO)');
+        $this->logger->notice('Retrieving the users display name failed in the user storage (PDO)');
     }
 
     public function getNotificationType($userId)
@@ -100,7 +100,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
         if ($sth->execute(array($userId))) {
             return $sth->fetchColumn();
         }
-        $this->logger->error('Unable to retrieve notification type from user storage (PDO)');
+        $this->logger->notice('Unable to retrieve notification type from user storage (PDO)');
     }
     
     public function setNotificationType($userId, $type)
@@ -117,7 +117,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
         if ($sth->execute(array($userId))) {
             return $sth->fetchColumn();
         }
-        $this->logger->error('Unable to retrieve notification address from user storage (PDO)');
+        $this->logger->notice('Unable to retrieve notification address from user storage (PDO)');
     }
     
     public function setNotificationAddress($userId, $address)
@@ -134,7 +134,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
         if ($sth->execute(array($userId))) {
             return $sth->fetchColumn();
         }
-        $this->logger->error('Unable to retrieve login attempts from user storage (PDO)');
+        $this->logger->notice('Unable to retrieve login attempts from user storage (PDO)');
     }
     
     public function setLoginAttempts($userId, $amount)
@@ -212,7 +212,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
             if (null !== $timestamp) {
                 return $timestamp;
             } else {
-                $this->logger->info('No temp lock timestamp found in user storage for a given user (PDO)');
+                $this->logger->notice('No temp lock timestamp found in user storage for a given user (PDO)');
             }
         }
         return false;

--- a/library/tiqr/Tiqr/UserStorage/Pdo.php
+++ b/library/tiqr/Tiqr/UserStorage/Pdo.php
@@ -64,7 +64,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
         if ($sth->execute(array($displayName,$userId))){
             return $this->userExists($userId);
         }
-        $this->logger->error('The user could not be saved in the user storage (PDO)');
+        throw new Tiqr_Exception_ReadWriteException('The user could not be saved in the user storage (PDO)');
     }
 
     /**
@@ -107,7 +107,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
     {
         $sth = $this->handle->prepare("UPDATE ".$this->tablename." SET notificationtype = ? WHERE userid = ?");
         if (!$sth->execute(array($type,$userId))) {
-            $this->logger->error('Unable to set the notification type in user storage for a given user (PDO)');
+            throw new ReadWriteException('Unable to set the notification type in user storage for a given user (PDO)');
         }
     }
     
@@ -124,7 +124,8 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
     {
         $sth = $this->handle->prepare("UPDATE ".$this->tablename." SET notificationaddress = ?  WHERE userid = ?");
         if (!$sth->execute(array($address,$userId))) {
-            $this->logger->error('Unable to set the notification address in user storage for a given user (PDO)');
+            throw new ReadWriteException('Unable to set the notification address in user storage for a given user (PDO)');
+
         }
     }
     
@@ -141,7 +142,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
     {
         $sth = $this->handle->prepare("UPDATE ".$this->tablename." SET loginattempts = ? WHERE userid = ?");
         if (!$sth->execute(array($amount,$userId))) {
-            $this->logger->error('Unable to set login attempts in user storage for a given user (PDO)');
+            throw new ReadWriteException('Unable to set login attempts in user storage for a given user (PDO)');
         }
     }
     
@@ -167,14 +168,14 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
         $sth = $this->handle->prepare("UPDATE ".$this->tablename." SET blocked = ? WHERE userid = ?");
         $isBlocked = ($blocked) ? "1" : "0";
         if (!$sth->execute([$isBlocked, $userId])) {
-            $this->logger->error('Unable to block the user in the user storage (PDO)');
+            throw new ReadWriteException('Unable to block the user in the user storage (PDO)');
         }
     }
     
     public function setTemporaryBlockAttempts($userId, $amount) {
         $sth = $this->handle->prepare("UPDATE ".$this->tablename." SET tmpblockattempts = ? WHERE userid = ?");
         if (!$sth->execute(array($amount,$userId))) {
-            $this->logger->error('Unable to set temp login attempts in user storage for a given user (PDO)');
+            throw new ReadWriteException('Unable to set temp login attempts in user storage for a given user (PDO)');
         }
     }
 
@@ -199,7 +200,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
     {
         $sth = $this->handle->prepare("UPDATE ".$this->tablename." SET tmpblocktimestamp = ? WHERE userid = ?");
         if (!$sth->execute(array($timestamp,$userId))) {
-            $this->logger->error('Unable to update temp lock timestamp in user storage for a given user (PDO)');
+            throw new ReadWriteException('Unable to update temp lock timestamp in user storage for a given user (PDO)');
         }
     }
             
@@ -217,5 +218,4 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
         }
         return false;
     }
-    
 }

--- a/library/tiqr/Tiqr/UserStorage/Pdo.php
+++ b/library/tiqr/Tiqr/UserStorage/Pdo.php
@@ -64,7 +64,7 @@ class Tiqr_UserStorage_Pdo extends Tiqr_UserStorage_Abstract
         if ($sth->execute(array($displayName,$userId))){
             return $this->userExists($userId);
         }
-        throw new Tiqr_Exception_ReadWriteException('The user could not be saved in the user storage (PDO)');
+        throw new ReadWriteException('The user could not be saved in the user storage (PDO)');
     }
 
     /**

--- a/library/tiqr/tests/Tiqr_ServiceTest.php
+++ b/library/tiqr/tests/Tiqr_ServiceTest.php
@@ -23,31 +23,35 @@ class Tiqr_ServiceTest extends TestCase
             'name' => 'Test service name',
             'logoUrl' => 'http://tiqr.example.org/logoUrl',
             'infoUrl' => 'http://tiqr.example.org/infoUrl',
-            // 'phpqrcode.path'
-            // 'apns.path'
-            // 'apns.certificate'
             'apns.environment' => 'sandbox',
-            'statestorage' => array(
+            'statestorage' => [
                 'type' => 'file',
-            ),
-            'devicestorage' => array(
+                'path' => '/tmp',
+            ],
+            'devicestorage' => [
                 'type' => 'dummy',
-            )
+            ]
         );
     }
 
     // Test creating a new tiqr service
     public function testDefaultConstructor() {
         $_SERVER['SERVER_NAME'] = 'dummy.example.org';
-        $service = new Tiqr_Service($this->logger);
+        $service = new Tiqr_Service($this->logger, ['statestorage' => ['type' => 'file', 'path' => '/src']]);
+        $this->assertInstanceOf(Tiqr_Service::class, $service);
+    }
+
+    // Test creating a new tiqr service
+    public function testDefaultConstructorPathOnFileStateStorageIsRequired() {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The path is missing in the StateStorage configuration');
+        $service = new Tiqr_Service($this->logger, ['statestorage' => ['type' => 'file']]);
         $this->assertInstanceOf(Tiqr_Service::class, $service);
     }
 
     public function testOptions() {
-
         $service = new Tiqr_Service($this->logger, $this->getOptions());
         $this->assertInstanceOf(Tiqr_Service::class, $service);
-
         $this->assertSame($service->getIdentifier(), 'test.identifier.example.org');
     }
 

--- a/library/tiqr/tests/Tiqr_StateStoragePdoTest.php
+++ b/library/tiqr/tests/Tiqr_StateStoragePdoTest.php
@@ -72,9 +72,13 @@ class Tiqr_StateStoragePdoTest extends TestCase
         // declared to prevent expectation errors. Covering them in the expectation above
         // raises side effects, as it becomes impossible to tell in what order the prepare
         // statement is called.
+        $statement = m::mock(PDOStatement::class)->shouldIgnoreMissing();
         $this->pdoInstance
             ->shouldReceive('prepare')
-            ->andReturn(m::mock(PDOStatement::class)->shouldIgnoreMissing());
+            ->andReturn($statement);
+        $statement
+            ->shouldReceive('execute')
+            ->andReturn(true);
 
         $this->stateStorage->setValue('key', 'data', 1);
     }

--- a/library/tiqr/tests/Tiqr_StateStorageTest.php
+++ b/library/tiqr/tests/Tiqr_StateStorageTest.php
@@ -56,7 +56,7 @@ class Tiqr_StateStorageTest extends TestCase
 
     public function test_unsetting_a_non_existing_key_results_in_error() {
         $stateStorage = $this->createStateStorage();
-        $this->expectException(Tiqr_Exception_ReadWriteException::class);
+        $this->expectException(ReadWriteException::class);
         $stateStorage->unsetValue('i-do-not-exist');
     }
 

--- a/library/tiqr/tests/Tiqr_StateStorageTest.php
+++ b/library/tiqr/tests/Tiqr_StateStorageTest.php
@@ -26,7 +26,7 @@ class Tiqr_StateStorageTest extends TestCase
 
     function testStateStorage_File() {
         // No config, always writes to /tmp
-        $ss=Tiqr_StateStorage::getStorage("file", array(), $this->logger);
+        $ss = Tiqr_StateStorage::getStorage("file", ['path' => '/tmp'], $this->logger);
         $this->assertInstanceOf(Tiqr_StateStorage_File::class, $ss);
 
         $this->stateTests($ss);
@@ -101,7 +101,7 @@ SQL
         ];
     }
 
-    private function stateTests(Tiqr_StateStorage_Abstract $ss) {
+    private function stateTests(Tiqr_StateStorage_StateStorageInterface $ss) {
         $ss->unsetValue("nonexistent_key");
 
         // Gettng nonexistent value returns NULL

--- a/library/tiqr/tests/Tiqr_StateStorageTest.php
+++ b/library/tiqr/tests/Tiqr_StateStorageTest.php
@@ -2,11 +2,13 @@
 
 require_once 'tiqr_autoloader.inc';
 
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class Tiqr_StateStorageTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
     /**
      * @var LoggerInterface
      */
@@ -17,14 +19,16 @@ class Tiqr_StateStorageTest extends TestCase
         $this->logger = Mockery::mock(LoggerInterface::class)->shouldIgnoreMissing();
     }
 
-    private function makeTempDir() {
+    private function makeTempDir()
+    {
         $t=tempnam(sys_get_temp_dir(),'Tiqr_StateStorageTest');
         unlink($t);
         mkdir($t);
         return $t;
     }
 
-    public function testStateStorage_File() {
+    public function testStateStorage_File()
+    {
         // No config, always writes to /tmp
         $ss = Tiqr_StateStorage::getStorage("file", ['path' => '/tmp'], $this->logger);
         $this->assertInstanceOf(Tiqr_StateStorage_File::class, $ss);
@@ -46,17 +50,18 @@ class Tiqr_StateStorageTest extends TestCase
         Tiqr_StateStorage::getStorage("Fictional_Service_That_Was_Implements_StateStorage.php", array(), $this->logger);
     }
 
-    public function testStateStorage_Pdo() {
-
+    public function testStateStorage_Pdo()
+    {
         $stateStorage = $this->createStateStorage();
         $this->assertInstanceOf(Tiqr_StateStorage_Pdo::class, $stateStorage);
 
         $this->stateTests($stateStorage);
     }
 
-    public function test_unsetting_a_non_existing_key_results_in_error() {
+    public function test_unsetting_a_non_existing_key_does_not_result_in_error()
+    {
         $stateStorage = $this->createStateStorage();
-        $this->expectException(ReadWriteException::class);
+        $this->logger->shouldReceive('info')->once();
         $stateStorage->unsetValue('i-do-not-exist');
     }
 
@@ -83,7 +88,8 @@ class Tiqr_StateStorageTest extends TestCase
         ];
     }
 
-    private function stateTests(Tiqr_StateStorage_StateStorageInterface $ss) {
+    private function stateTests(Tiqr_StateStorage_StateStorageInterface $ss)
+    {
         // Gettng nonexistent value returns NULL
         $this->assertEquals(NULL,  $ss->getValue("nonexistent_key"));
 

--- a/library/tiqr/tests/Tiqr_UserSecretStorageTest.php
+++ b/library/tiqr/tests/Tiqr_UserSecretStorageTest.php
@@ -14,7 +14,7 @@ class Tiqr_UserSecretStorageTest extends TestCase
     {
         $allOptions = [
             'path' => './',
-            'dsn' => 'foobar:user:pass',
+            'dsn' => 'sqlite:/tmp/db.sqlite',
             'username'=> 'user',
             'password'=>'secret',
             'apiURL'=>'',

--- a/library/tiqr/tests/Tiqr_UserSecretStorage_PdoTest.php
+++ b/library/tiqr/tests/Tiqr_UserSecretStorage_PdoTest.php
@@ -66,7 +66,7 @@ class Tiqr_UserSecretStorage_PdoTest extends TestCase
             ->with('UPDATE tiqrusersecret SET secret = ? WHERE userid = ?')
             ->andReturn($updateStatement);
 
-        $this->expectException(Tiqr_Exception_ReadWriteException::class);
+        $this->expectException(ReadWriteException::class);
         $this->expectExceptionMessage('Unable to persist user secret in user secret storage (PDO)');
         $store->setSecret('UserId', 'My Secret');
     }

--- a/library/tiqr/tests/Tiqr_UserSecretStorage_PdoTest.php
+++ b/library/tiqr/tests/Tiqr_UserSecretStorage_PdoTest.php
@@ -17,12 +17,17 @@ class Tiqr_UserSecretStorage_PdoTest extends TestCase
      */
     private $dsn;
 
+    /**
+     * @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|PDO
+     */
+    private $pdoInstance;
+
     protected function setUp(): void
     {
         $targetPath = $this->makeTempDir();
         $this->dsn = 'sqlite:' . $targetPath . '/state.sq3';
         $this->setUpDatabase($this->dsn);
-        $pdoInstance = new PDO($this->dsn, null, null);
+        $pdoInstance = new PDO($this->dsn, 'root', 'secret');
         $this->pdoInstance = Mockery::mock($pdoInstance);
         $this->logger = Mockery::mock(LoggerInterface::class)->shouldIgnoreMissing();
     }
@@ -37,6 +42,33 @@ class Tiqr_UserSecretStorage_PdoTest extends TestCase
     {
         // For refactoring: user secret storage should not be on the user storage anymore
         $this->assertClassNotHasAttribute('_userSecretStorage', Tiqr_UserStorage_Pdo::class);
+    }
+
+    public function test_exception_expected_when_set_secret_fails()
+    {
+        $store = $this->buildUserSecretStorage();
+
+        $selectStatement = Mockery::mock(PDOStatement::class);
+        $selectStatement->shouldReceive('execute')->andReturn(true);
+        $selectStatement->shouldReceive('fetchColumn')->andReturn('user1');
+
+        $updateStatement = Mockery::mock(PDOStatement::class);
+        $updateStatement->shouldReceive('execute')->andReturn(false);
+
+        $this->pdoInstance
+            ->shouldReceive('prepare')
+            ->with('SELECT userid FROM tiqrusersecret WHERE userid = ?')
+            ->andReturn($selectStatement);
+
+
+        $this->pdoInstance
+            ->shouldReceive('prepare')
+            ->with('UPDATE tiqrusersecret SET secret = ? WHERE userid = ?')
+            ->andReturn($updateStatement);
+
+        $this->expectException(Tiqr_Exception_ReadWriteException::class);
+        $this->expectExceptionMessage('Unable to persist user secret in user secret storage (PDO)');
+        $store->setSecret('UserId', 'My Secret');
     }
 
     public function test_it_can_store_and_retrieve_an_user_secret()
@@ -68,9 +100,7 @@ class Tiqr_UserSecretStorage_PdoTest extends TestCase
         return new Tiqr_UserSecretStorage_Pdo(
             new Tiqr_UserSecretStorage_Encryption_Dummy([]),
             $this->logger,
-            $this->dsn,
-            'root',
-            'secret',
+            $this->pdoInstance,
             'tiqrusersecret'
         );
     }


### PR DESCRIPTION
This was previously only writing to the /tmp directory. It is now required to select a path to store the storage items in.

See: https://www.pivotaltracker.com/story/show/181817180