### PR TITLE
Add support for the new HTTP/2 based Apple push notification service

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -13,12 +13,7 @@ coding_style:
     
 build:
     environment:
-        apt_packages:
-          - libcurl
-        php: 7.2
-        pecl_extensions:
-          - intl
-          - gmp
+        php: 7.2       
     dependencies:
         override:
             - composer install --no-interaction --no-scripts --ignore-platform-req

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -13,7 +13,12 @@ coding_style:
     
 build:
     environment:
+        apt_packages:
+          - libcurl
         php: 7.2
+        pecl_extensions:
+          - intl
+          - gmp
     nodes:
         analysis:
             tests:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -19,6 +19,9 @@ build:
         pecl_extensions:
           - intl
           - gmp
+    dependencies:
+        override:
+            - composer install --no-interaction --no-scripts --ignore-platform-req
     nodes:
         analysis:
             tests:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -16,7 +16,7 @@ build:
         php: 7.2       
     dependencies:
         override:
-            - composer install --no-interaction --no-scripts --ignore-platform-req
+            - composer install --no-interaction --no-scripts --ignore-platform-reqs
     nodes:
         analysis:
             tests:

--- a/Dockerfile.testserver
+++ b/Dockerfile.testserver
@@ -20,17 +20,21 @@ RUN mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 # Disable openssl seclevel to allow md5, required for the ssl connection to the APNS gateway
 RUN sed -i -e 's/SECLEVEL=2/SECLEVEL=0/g' /etc/ssl/openssl.cnf
 
-# install php gd (for tiqr) and zip (for composer) extensions
+# install php gd (for tiqr), zip (for composer) and gmp and intl (for APNS HTTP/2)
 RUN apt-get update && apt-get install -y \
 		libfreetype6-dev \
 		libjpeg62-turbo-dev \
 		libpng-dev \
-        zlib1g-dev \
-        libzip-dev \
-        unzip \
+    zlib1g-dev \
+    libzip-dev \
+    unzip \
+    libgmp-dev \
+    libicu-dev \
 	&& docker-php-ext-configure gd --with-freetype --with-jpeg \
 	&& docker-php-ext-install -j$(nproc) gd \
-    && docker-php-ext-install zip
+  && docker-php-ext-install zip \
+  && docker-php-ext-install gmp \
+  && docker-php-ext-install intl
 
 # install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer 

--- a/TestServer/TestServerController.php
+++ b/TestServer/TestServerController.php
@@ -121,6 +121,7 @@ class TestServerController
                 // APNS
                 'apns.certificate' => $apns_cert_filename,
                 'apns.environment' => $apns_environment,
+                'apns.version' => 2,    // Use the new HTTP/2 based protocol
 
                 // FCM
                 'firebase.apikey' => $firebase_apikey,

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,9 @@
         "ext-curl": "*",
         "ext-json": "*",
         "php": ">=7.2",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1",
+        "edamov/pushok": "^0.14.0",
+        "ext-openssl": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/library/tiqr/Tiqr/Message/APNS2.php
+++ b/library/tiqr/Tiqr/Message/APNS2.php
@@ -1,0 +1,111 @@
+<?php
+
+use Pushok\AuthProvider;
+use Pushok\Client;
+use Pushok\Notification;
+use Pushok\Payload;
+use Pushok\Payload\Alert;
+
+/** @internal includes */
+require_once('Tiqr/Message/Abstract.php');
+
+/**
+ * Apple Push Notification Service message class for the HTTP/2 api.push.apple.com APNs API.
+ */
+class Tiqr_Message_APNS2 extends Tiqr_Message_Abstract
+{
+    /**
+     * Send message.
+     */
+    public function send()
+    {
+        $version_info = curl_version();
+        if ($version_info['features'] & CURL_VERSION_HTTP2 == 0) {
+            throw new RuntimeException('APNS2 requires HTTP/2 support in curl');
+        }
+
+        // Get the UID from the client certificate we use for authentication, this
+        // is set to the bundle ID.
+        $options=$this->getOptions();
+        $cert_filename = $options['apns.certificate'];
+        $cert_file_contents = file_get_contents($cert_filename);
+        if (false === $cert_file_contents) {
+            throw new RuntimeException(
+                sprintf('Error reading APNS client certificate file: "%s"', $cert_filename)
+            );
+        }
+
+        $cert=openssl_x509_parse( $cert_file_contents );
+        if (false === $cert) {
+            throw new RuntimeException('Error parsing APNS client certificate');
+        }
+        $bundle_id = $cert['subject']['UID'] ?? NULL;
+        if (NULL === $bundle_id) {
+            throw new RuntimeException('No uid found in the certificate subject');
+        }
+        $this->logger->info(sprintf('Setting bundle_id to "%s" based on UID from certificate', $bundle_id));
+        $this->logger->info(
+            sprintf('Authenticating using certificate with subject "%s" valid until "%s"',
+                $cert['name'],
+                date(DATE_RFC2822, $cert['validTo_time_t'])
+            )
+        );
+
+        $authProviderOptions = [
+            'app_bundle_id' => $bundle_id, // The bundle ID for app obtained from Apple developer account
+            'certificate_path' => $cert_filename,
+            'certificate_secret' => null // Private key secret
+        ];
+
+        $authProvider = AuthProvider\Certificate::create($authProviderOptions);
+
+        // Create the push message
+        $alert=Alert::create();
+        $alert->setBody($this->getText());
+        // TODO: Set title?
+        $payload=Payload::create()->setAlert($alert);
+        $payload->setSound('default');
+        // TODO: Can we set an expiry time for the message?
+        foreach ($this->getCustomProperties() as $name => $value) {
+            $payload->setCustomValue($name, $value);
+        }
+        $this->logger->debug(sprintf('JSON Payload: %s', $payload->toJson()));
+        $notification=new Notification($payload, $this->getAddress());
+
+        // Send the push message
+        $client = new Client($authProvider, $options['apns.environment'] == 'production');
+        $client->addNotification($notification);
+        $responses=$client->push();
+        if ( sizeof($responses) != 1) {
+            $this->logger->warning('Unexpected number responses. Expected 1, got %n', sizeof($responses) );
+            if (sizeof($responses) == 0) {
+                $this->logger->warning('Could not determine whether the notification was sent');
+                return;
+            }
+        }
+        /** @var \Pushok\Response $response */
+        $response = reset($responses);  // Get first response from the array
+        $deviceToken=$response->getDeviceToken() ?? '';
+        // A canonical UUID that is the unique ID for the notification. E.g. 123e4567-e89b-12d3-a456-4266554400a0
+        $apnsId=$response->getApnsId() ?? '';
+        // Status code. E.g. 200 (Success), 410 (The device token is no longer active for the topic.)
+        $statusCode=$response->getStatusCode();
+        $this->logger->info(sprintf('Got response with ApnsId "%s", status %s for deviceToken "%s"', $apnsId, $statusCode, $deviceToken));
+        if ( strcasecmp($deviceToken, $this->getAddress()) ) {
+        $this->logger->warning(sprintf('Unexpected deviceToken in response. Expected: "%s"; got: "%s"', $this->getAddress(), $deviceToken));
+        }
+        if ($statusCode == 200) {
+            $this->logger->notice(sprintf('Successfully sent APNS2 push notification. APNS ID: "%s"; deviceToken: "%s"', $apnsId, $deviceToken));
+            return;
+        }
+
+        $reasonPhrase=$response->getReasonPhrase(); // E.g. The device token is no longer active for the topic.
+        $errorReason=$response->getErrorReason(); // E.g. Unregistered
+        $errorDescription=$response->getErrorDescription(); // E.g. The device token is inactive for the specified topic.
+
+        $this->logger->error(sprintf('Error sending APNS2 push notification. APNS ID: "%s"; deviceToken: "%s"; Error: "%s" "%s" "%s"', $apnsId, $deviceToken, $reasonPhrase, $errorReason, $errorDescription));
+        throw new RuntimeException(
+            sprintf('Error sending APNS2 push notification. Status: %s. Error: "%s" "%s" "%s"', $statusCode, $reasonPhrase, $errorReason, $errorDescription)
+        );
+    }
+}

--- a/library/tiqr/Tiqr/Message/APNS2.php
+++ b/library/tiqr/Tiqr/Message/APNS2.php
@@ -77,7 +77,7 @@ class Tiqr_Message_APNS2 extends Tiqr_Message_Abstract
         $client->addNotification($notification);
         $responses=$client->push();
         if ( sizeof($responses) != 1) {
-            $this->logger->warning('Unexpected number responses. Expected 1, got %n', sizeof($responses) );
+            $this->logger->warning(sprintf('Unexpected number responses. Expected 1, got %d', sizeof($responses)) );
             if (sizeof($responses) == 0) {
                 $this->logger->warning('Could not determine whether the notification was sent');
                 return;

--- a/library/tiqr/Tiqr/Message/APNS2.php
+++ b/library/tiqr/Tiqr/Message/APNS2.php
@@ -62,15 +62,19 @@ class Tiqr_Message_APNS2 extends Tiqr_Message_Abstract
         // Create the push message
         $alert=Alert::create();
         $alert->setBody($this->getText());
-        // TODO: Set title?
+        // Note: It is possible to specify a title and a subtitle: $alert->setTitle() && $alert->setSubtitle()
+        //       The tiqr service currently does not implement this.
         $payload=Payload::create()->setAlert($alert);
         $payload->setSound('default');
-        // TODO: Can we set an expiry time for the message?
         foreach ($this->getCustomProperties() as $name => $value) {
             $payload->setCustomValue($name, $value);
         }
         $this->logger->debug(sprintf('JSON Payload: %s', $payload->toJson()));
         $notification=new Notification($payload, $this->getAddress());
+        // Set expiration to 30 seconds from now, same as Message_APNS
+        $now = new DateTimeImmutable();
+        $expirationInstant=$now->add(new DateInterval('PT30S'));
+        $notification->setExpirationAt($expirationInstant);
 
         // Send the push message
         $client = new Client($authProvider, $options['apns.environment'] == 'production');

--- a/library/tiqr/Tiqr/Message/Abstract.php
+++ b/library/tiqr/Tiqr/Message/Abstract.php
@@ -17,6 +17,7 @@
  * @copyright (C) 2010-2011 SURFnet BV
  */
 
+use Psr\Log\LoggerInterface;
 
 /**
  * Abstract base class for notification messages.
@@ -28,15 +29,18 @@ abstract class Tiqr_Message_Abstract
     private $_address;
     private $_text;
     private $_properties = array();
+    /** @var LoggerInterface */
+    protected $logger;
     
     /**
      * Construct a new message.
      *
      * @param array $options configuration options
      */
-    public function __construct($options)
+    public function __construct($options, LoggerInterface $logger)
     {
         $this->_options = $options;
+        $this->logger = $logger;
     }
     
     /**

--- a/library/tiqr/Tiqr/Service.php
+++ b/library/tiqr/Tiqr/Service.php
@@ -223,6 +223,9 @@ class Tiqr_Service
      *                     in PEM format.
      *                     Defaults to ../certificates/cert.pem
      * - apns.environment: Whether to use apple's "sandbox" or "production" apns environment
+     * - apns.version:     Which version of the APNS protocol to use. Default: 1
+     *                     Version 1: The deprecated binary APNS protocol (gateway.push.apple.com)
+     *                     Version 2: The HTTP/2 based protocol (api.push.apple.com)
      * * For sending push notifications to Android devices using Google's firebase cloud messaging (FCM) API
      * - firebase.apikey: String containing the FCM API key
      *
@@ -339,13 +342,17 @@ class Tiqr_Service
             switch ($notificationType) {
                 case 'APNS':
                 case 'APNS_DIRECT':
-                    $message = new Tiqr_Message_APNS($this->_options);
+                    $apns_version = $this->_options['apns.version'] ?? 1;
+                    if ($apns_version ==2 )
+                        $message = new Tiqr_Message_APNS2($this->_options, $this->logger);
+                    else
+                        $message = new Tiqr_Message_APNS($this->_options, $this->logger);
                     break;
 
                 case 'GCM':
                 case 'FCM':
                 case 'FCM_DIRECT':
-                    $message = new Tiqr_Message_FCM($this->_options);
+                    $message = new Tiqr_Message_FCM($this->_options, $this->logger);
                     break;
 
                 default:


### PR DESCRIPTION
Add a APNS2 message class using [edamov/pushok](https://github.com/edamov/pushok) that supports sending push notifications using the new Apple HTTP/2 api

Update the TestServer to use APNS2.