### PR TITLE
Update psr/log version constraint from 1 to 3

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -4,28 +4,29 @@ on:
   push:
     branches: [ master, develop ]
 jobs:
-  build:
+  run-qa-tests:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: /var/www/html/
+    container:
+      image:  ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:latest
+      volumes:
+        - .:/var/www/html
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-      - name: Init environment
-        run: cd ci/docker && docker-compose up -d
-      - name: Install dependencies
-        run: cd ci/docker && docker-compose exec -T tiqr-server-libphp bash -lc 'composer install'
+        uses: actions/checkout@v2
+
+      - name: Composer install
+        run: composer install
+
       - name: Run test scripts (allowed to fail)
-        run: cd ci/docker && docker-compose exec -T tiqr-server-libphp bash -lc 'composer static-analysis'
+        run: composer static-analysis
+
       - name: Run test scripts
-        run: cd ci/docker && docker-compose exec -T tiqr-server-libphp bash -lc 'composer phpunit && composer security-tests'
+        run: composer phpunit && composer security-tests
+
       - name: Output log files on failure
         if: failure()
         run: tail -2000 /var/log/syslog

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -1,8 +1,0 @@
-version: '3.7'
-
-services:
-  tiqr-server-libphp:
-    stdin_open: true
-    image: ghcr.io/openconext/openconext-containers/openconext-php-test-stepup:latest
-    volumes:
-      - ../../:/var/www

--- a/composer.json
+++ b/composer.json
@@ -7,18 +7,23 @@
         "ext-gd": "*",
         "ext-curl": "*",
         "ext-json": "*",
-        "php": ">=7.2",
         "psr/log": "^3.0",
         "edamov/pushok": "^0.14.0",
         "ext-openssl": "*",
         "chillerlan/php-qrcode": "^3.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^9.6",
         "ext-pdo_sqlite": "*",
-        "mockery/mockery": "^1.3",
-        "phpmd/phpmd": "^2.12",
-        "squizlabs/php_codesniffer": "^2.9.2"
+        "mockery/mockery": "^1.6",
+        "phpmd/phpmd": "^2.15",
+        "squizlabs/php_codesniffer": "^3.7"
+    },
+    "config": {
+        "sort-packages": true,
+        "platform": {
+            "php": "8.2"
+        }
     },
     "scripts": {
         "test": [

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "php": ">=7.2",
-        "psr/log": "^1.1",
+        "psr/log": "^3.0",
         "edamov/pushok": "^0.14.0",
         "ext-openssl": "*",
         "chillerlan/php-qrcode": "^3.4"


### PR DESCRIPTION
To be compat with Symfony 6 (and specifically with SF's integration with Monolog). We need to raise the PSR/Log constraint to either 2 or 3. I'm opting to stick it at 3. The major differences between the versions are summarized below.

BC change from 1 to 2: require PHP 8.0 or higher
BC change from 2 to 3: makes the log methods type safer (adds return typ void)