### PR TITLE
Update FCM to use HTTP v1 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ TestServer/config/
 coverage.xml
 *~
 TestServer/storage/
+TestServer/config.dist/config/google.json
+TestServer/config/config

--- a/FCM.md
+++ b/FCM.md
@@ -1,0 +1,25 @@
+# FCM voor Tiqr
+
+## Prepare
+
+- Log in to the [Google cloud console](https://console.cloud.google.com/)
+- Create or select a project. Copy the project ID and enter it in the config as `firebase_projectId`
+
+## Add a new role
+
+- Go to `IAM & Admin` and select `roles` in the left menu
+- Create a new role, and name it `CloudMessaging` in the title and id, set it to General Availibility.
+- Assign two permissions: `cloudmessaging.messages.create` and `firebasecloudmessaging.messages.create` and click `Create`
+
+## Add a new serviceaccount and key
+- Go to `API's& Services`, and click `+ Enable API's and Services`
+- Search for `firebase cloud messaging api` and enable it
+- Next, go to `Credentials` and create a new credential. Choose for the service account, enter a name, and ID, and copy the email-address renerated
+- Open the newl user and vanigate to the `keys` tab. Add a new key, and chose the json format. The downloaded file should be places in the config directory and configured in the config file as `firebase_credentialsFile`
+
+## Grant permissions
+
+- Open a cloud shell (Icon in the top-richt corner).
+- Assign the role to the user by running : `gcloud projects add-iam-policy-binding <projectID> --member=serviceAccount:<serviceaccount-email> --role=projects/<projectID/roles/CloudMessaging`
+
+

--- a/FCM.md
+++ b/FCM.md
@@ -14,12 +14,12 @@
 ## Add a new serviceaccount and key
 - Go to `API's& Services`, and click `+ Enable API's and Services`
 - Search for `firebase cloud messaging api` and enable it
-- Next, go to `Credentials` and create a new credential. Choose for the service account, enter a name, and ID, and copy the email-address renerated
-- Open the newl user and vanigate to the `keys` tab. Add a new key, and chose the json format. The downloaded file should be places in the config directory and configured in the config file as `firebase_credentialsFile`
+- Next, go to `Credentials` and create a new credential. Choose for the service account, enter a name, and ID, and copy the email-address generated
+- Open the newl user and navigate to the `keys` tab. Add a new key, and chose the json format. The downloaded file should be places in the config directory and configured in the config file as `firebase_credentialsFile`
 
 ## Grant permissions
 
-- Open a cloud shell (Icon in the top-richt corner).
+- Open a cloud shell (Icon in the top-right corner).
 - Assign the role to the user by running : `gcloud projects add-iam-policy-binding <projectID> --member=serviceAccount:<serviceaccount-email> --role=projects/<projectID/roles/CloudMessaging`
 
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ $options = [
     // APNS configuration, required for sending push notifications to iOS devices
     'apns.certificate' => 'files/apns.pem',
     'apns.environment' => 'production',
-
-    // FCM configuration, required for sending push notifications to Android devices
-    'firebase.apikey' => 'your-secret-firebase-api-key',
+    
+    //FCM configuration, required for sending push notifications to Android devices
+    'firebase.projectId' => '12345-abcde',
+    'firebase.credentialsFile' => 'google.json',    
 
     // Session storage
     'statestorage' => [
@@ -105,6 +106,8 @@ $options = [
     ],
 ]
 ```
+
+[See this instructions](FCM.md) for generating the `firebase.projectId` and `firebase.credentialsFile`
 
 ### Autoloading and composer
 

--- a/TestServer/TestServerController.php
+++ b/TestServer/TestServerController.php
@@ -48,15 +48,16 @@ class TestServerController
      *
      * @param string $apns_certificate_filename The filename of the file with PEM APNS signing certificate and private key
      * @param string $apns_environment The APNS environment to use. 'production' or 'sandbox'
-     * @param string $firebase_apikey The Google firebase API key. Required for sending FCM push notifications
+     * @param string $firebase_projectId The firebase project ID
+     * @param string $firebase_credentialsFile The file containing the firebase secrets json
      * @param string $storage_dir Directory to use for tiqr state storage, user storage and user sercret storage
      */
-    function __construct(LoggerInterface $logger, string $host_url, string $authProtocol, string $enrollProtocol, string $token_exchange_url, string $token_exchange_appid, string $apns_certificate_filename, string $apns_environment, string $firebase_apikey, string $storage_dir)
+    function __construct(LoggerInterface $logger, string $host_url, string $authProtocol, string $enrollProtocol, string $token_exchange_url, string $token_exchange_appid, string $apns_certificate_filename, string $apns_environment, string $firebase_projectId, string $firebase_credentialsFile, string $storage_dir)
     {
         $this->storageDir = $storage_dir;
         $this->logger = $logger;
         $this->host_url = $host_url;
-        $this->tiqrService = $this->createTiqrService($host_url, $authProtocol, $enrollProtocol, $token_exchange_url, $token_exchange_appid, $apns_certificate_filename, $apns_environment, $firebase_apikey);
+        $this->tiqrService = $this->createTiqrService($host_url, $authProtocol, $enrollProtocol, $token_exchange_url, $token_exchange_appid, $apns_certificate_filename, $apns_environment, $firebase_projectId, $firebase_credentialsFile );
         $this->userStorage = $this->createUserStorage();
         $this->userSecretStorage = $this->createUserSecretStorage();        
     }
@@ -79,7 +80,7 @@ class TestServerController
     /**
      * @return Tiqr_Service
      */
-    private function createTiqrService($host, $authProtocol, $enrollProtocol, $token_exchange_url, $token_exchange_appid, $apns_cert_filename, $apns_environment, $firebase_apikey)
+    private function createTiqrService($host, $authProtocol, $enrollProtocol, $token_exchange_url, $token_exchange_appid, $apns_cert_filename, $apns_environment, $firebase_projectId, $firebase_credentialsFile)
     {
         // Derive the identifier from the host
         $identifier = parse_url($host, PHP_URL_HOST);
@@ -104,7 +105,9 @@ class TestServerController
                 'apns.version' => 2,    // Use the new HTTP/2 based protocol
 
                 // FCM
-                'firebase.apikey' => $firebase_apikey,
+                'firebase.projectId' => $firebase_projectId,
+                'firebase.credentialsFile' => $firebase_credentialsFile,
+
 
                 // Note: C2DM is no longer supported by google (https://developers.google.com/android/c2dm)
                 'c2dm.username' => 'test_c2dm_username',

--- a/TestServer/TestServerController.php
+++ b/TestServer/TestServerController.php
@@ -51,13 +51,15 @@ class TestServerController
      * @param string $firebase_projectId The firebase project ID
      * @param string $firebase_credentialsFile The file containing the firebase secrets json
      * @param string $storage_dir Directory to use for tiqr state storage, user storage and user sercret storage
+     * @param bool $firebase_cacheTokens Is the cache for accesstokens enabled
+     * @param string $firebase_tokenCacheDir Where is the cache for accesstokens located
      */
-    function __construct(LoggerInterface $logger, string $host_url, string $authProtocol, string $enrollProtocol, string $token_exchange_url, string $token_exchange_appid, string $apns_certificate_filename, string $apns_environment, string $firebase_projectId, string $firebase_credentialsFile, string $storage_dir)
+    function __construct(LoggerInterface $logger, string $host_url, string $authProtocol, string $enrollProtocol, string $token_exchange_url, string $token_exchange_appid, string $apns_certificate_filename, string $apns_environment, string $firebase_projectId, string $firebase_credentialsFile, string $storage_dir, bool $firebase_cacheTokens, string $firebase_tokenCacheDir)
     {
         $this->storageDir = $storage_dir;
         $this->logger = $logger;
         $this->host_url = $host_url;
-        $this->tiqrService = $this->createTiqrService($host_url, $authProtocol, $enrollProtocol, $token_exchange_url, $token_exchange_appid, $apns_certificate_filename, $apns_environment, $firebase_projectId, $firebase_credentialsFile );
+        $this->tiqrService = $this->createTiqrService($host_url, $authProtocol, $enrollProtocol, $token_exchange_url, $token_exchange_appid, $apns_certificate_filename, $apns_environment, $firebase_projectId, $firebase_credentialsFile, $firebase_cacheTokens, $firebase_tokenCacheDir );
         $this->userStorage = $this->createUserStorage();
         $this->userSecretStorage = $this->createUserSecretStorage();        
     }
@@ -80,7 +82,7 @@ class TestServerController
     /**
      * @return Tiqr_Service
      */
-    private function createTiqrService($host, $authProtocol, $enrollProtocol, $token_exchange_url, $token_exchange_appid, $apns_cert_filename, $apns_environment, $firebase_projectId, $firebase_credentialsFile)
+    private function createTiqrService($host, $authProtocol, $enrollProtocol, $token_exchange_url, $token_exchange_appid, $apns_cert_filename, $apns_environment, $firebase_projectId, $firebase_credentialsFile, $firebase_cacheTokens, $firebase_tokenCacheDir)
     {
         // Derive the identifier from the host
         $identifier = parse_url($host, PHP_URL_HOST);
@@ -107,7 +109,8 @@ class TestServerController
                 // FCM
                 'firebase.projectId' => $firebase_projectId,
                 'firebase.credentialsFile' => $firebase_credentialsFile,
-
+                'firebase.cacheTokens' => $firebase_cacheTokens,
+                'firebase.tokenCacheDir' => $firebase_tokenCacheDir,
 
                 // Note: C2DM is no longer supported by google (https://developers.google.com/android/c2dm)
                 'c2dm.username' => 'test_c2dm_username',

--- a/TestServer/app.php
+++ b/TestServer/app.php
@@ -41,10 +41,11 @@ $token_exchange_url = $config['token_exchange_url'] ?? 'https://tx.tiqr.org/toke
 $token_exchange_appid = $config['token_exchange_appid'] ?? 'tiqr';
 $apns_certificate_filename =  App::realpath($config['apns_certificate_filename'] ?? '', $config_dir);
 $apns_environment =  $config['apns_environment'] ?? 'sandbox';
-$firebase_apikey = $config['firebase_apikey'] ?? '';
+$firebase_projectId = $config['firebase_projectId'] ?? '';
+$firebase_credentialsFile = App::realpath($config['firebase_credentialsFile'] ?? '', $config_dir);
 
 $psr_logger = new TestServerPsrLogger();
-$test_server = new TestServerController($psr_logger, $host_url, $tiqrauth_protocol, $tiqrenroll_protocol, $token_exchange_url, $token_exchange_appid, $apns_certificate_filename, $apns_environment, $firebase_apikey, $storage_dir);
+$test_server = new TestServerController($psr_logger, $host_url, $tiqrauth_protocol, $tiqrenroll_protocol, $token_exchange_url, $token_exchange_appid, $apns_certificate_filename, $apns_environment, $firebase_projectId, $firebase_credentialsFile, $storage_dir);
 $app = new TestServerApp($test_server);
 $app->HandleHTTPRequest();
 

--- a/TestServer/app.php
+++ b/TestServer/app.php
@@ -23,7 +23,7 @@ require_once __DIR__ . '/TestServerPsrLogger.php';
 
 # Get config filename and directory
 $config_filename = 'config';
-$config_dir = __DIR__ . '/config/';
+$config_dir = __DIR__ . '/config';
 
 # Read configuration
 $config = array();
@@ -41,11 +41,13 @@ $token_exchange_url = $config['token_exchange_url'] ?? 'https://tx.tiqr.org/toke
 $token_exchange_appid = $config['token_exchange_appid'] ?? 'tiqr';
 $apns_certificate_filename =  App::realpath($config['apns_certificate_filename'] ?? '', $config_dir);
 $apns_environment =  $config['apns_environment'] ?? 'sandbox';
-$firebase_projectId = $config['firebase_projectId'] ?? '';
-$firebase_credentialsFile = App::realpath($config['firebase_credentialsFile'] ?? '', $config_dir);
+$firebase_projectId = $config['firebase_projectId'] ?? 'abc-1234';
+$firebase_credentialsFile = $config_dir . '/' . $config['firebase_credentialsFile'] ?? $config_dir . '/' . 'google.json';
+$firebase_cacheTokens = $config['$firebase_cacheTokens'] ?? false;
+$firebase_tokenCacheDir = $config['firebase_tokencachedir'] ?? $storage_dir;
 
 $psr_logger = new TestServerPsrLogger();
-$test_server = new TestServerController($psr_logger, $host_url, $tiqrauth_protocol, $tiqrenroll_protocol, $token_exchange_url, $token_exchange_appid, $apns_certificate_filename, $apns_environment, $firebase_projectId, $firebase_credentialsFile, $storage_dir);
+$test_server = new TestServerController($psr_logger, $host_url, $tiqrauth_protocol, $tiqrenroll_protocol, $token_exchange_url, $token_exchange_appid, $apns_certificate_filename, $apns_environment, $firebase_projectId, $firebase_credentialsFile, $storage_dir, $firebase_cacheTokens, $firebase_tokenCacheDir);
 $app = new TestServerApp($test_server);
 $app->HandleHTTPRequest();
 

--- a/TestServer/config.dist/config
+++ b/TestServer/config.dist/config
@@ -8,4 +8,5 @@
   "apns_environment" : "sandbox",
   "firebase_projectId" : "12345-abcde",
   "firebase_credentialsFile" : "google.json",
+  "firebase_cachetokens" : false,
 }

--- a/TestServer/config.dist/config
+++ b/TestServer/config.dist/config
@@ -6,5 +6,6 @@
   "token_exchange_appid" : "tiqr",
   "apns_certificate_filename" : "apns.pem",
   "apns_environment" : "sandbox",
-  "firebase_apikey" : ""
+  "firebase_projectId" : "12345-abcde",
+  "firebase_credentialsFile" : "google.json",
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "psr/log": "^1.1",
         "edamov/pushok": "^0.14.0",
         "ext-openssl": "*",
-        "chillerlan/php-qrcode": "^3.4"
+        "chillerlan/php-qrcode": "^3.4",
+        "google/apiclient": "^2.14"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "edamov/pushok": "^0.14.0",
         "ext-openssl": "*",
         "chillerlan/php-qrcode": "^3.4",
-        "google/apiclient": "^2.14"
+        "google/apiclient": "^2.14",
+        "cache/filesystem-adapter": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/library/tiqr/Tiqr/DeviceStorage/TokenExchange.php
+++ b/library/tiqr/Tiqr/DeviceStorage/TokenExchange.php
@@ -41,8 +41,18 @@ class Tiqr_DeviceStorage_TokenExchange extends Tiqr_DeviceStorage_Abstract
         $url = $this->_options["url"]."?appId=".$this->_options["appid"];
         
         $url.= "&notificationToken=".$notificationToken;
-        
-        $output = file_get_contents($url);
+
+        $ch = curl_init();
+
+        curl_setopt($ch, CURLOPT_AUTOREFERER, TRUE);
+        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+
+        $output = curl_exec($ch);
+        curl_close($ch);
+
         if (stripos($output, "not found")!==false) {
             $this->logger->error('Token Exchange failed and responded with: not found', ['full output' => $output]);
             return false;

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -16,6 +16,9 @@
  *
  * @copyright (C) 2010-2024 SURF BV
  */
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use Cache\Adapter\Filesystem\FilesystemCachePool;
 
 /**
  * Android Cloud To Device Messaging message.
@@ -47,7 +50,13 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
      * @throws \Google\Exception
      */
     private function getGoogleAccessToken($credentialsFile){
+        $filesystemAdapter = new Local(__DIR__.'/');
+        $filesystem        = new Filesystem($filesystemAdapter);
+
+        $pool = new FilesystemCachePool($filesystem);
+
         $client = new \Google_Client();
+        $client->setCache($pool);
         $client->setAuthConfig($credentialsFile);
         $client->addScope('https://www.googleapis.com/auth/firebase.messaging');
         $client->fetchAccessTokenWithAssertion();

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -52,6 +52,7 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
     private function getGoogleAccessToken($credentialsFile, $cacheTokens, $tokenCacheDir )
     {
         $client = new Google_Client();
+        $client->setLogger($this->logger);
         // Try to add a file based cache for accesstokens, if configured
         if ($cacheTokens) {
             //set up the cache

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -73,7 +73,7 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
         try {
             $client->setAuthConfig($credentialsFile);
         } catch (\Google\Exception $e) {
-            throw new Tiqr_Message_Exception_SendFailure(sprintf("Error setting Google credentials for FCM : %s", $e->getMessage()), true);
+            throw new Tiqr_Message_Exception_SendFailure(sprintf("Error setting Google credentials for FCM : %s", $e->getMessage()), true, $e);
         }
         $client->addScope('https://www.googleapis.com/auth/firebase.messaging');
         $client->fetchAccessTokenWithAssertion();

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -122,9 +122,9 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
 
         // handle errors, ignoring registration_id's
         $response = json_decode($result, true);
-        foreach ($response['results'] as $k => $v) {
-            if (isset($v['error'])) {
-                throw new Tiqr_Message_Exception_SendFailure("Error in FCM response: " . $v['error'], true);
+        foreach ($response as $k => $v) {
+            if ($k=="error") {
+                throw new Tiqr_Message_Exception_SendFailure(sprintf("Error in FCM response: %s", $result), true);
             }
         }
     }

--- a/library/tiqr/Tiqr/Service.php
+++ b/library/tiqr/Tiqr/Service.php
@@ -203,7 +203,8 @@ class Tiqr_Service
      * - apns.proxy_host_port: Set the proxy port to use with proxy_host_url. Optional. Defaults to 443.
      *
      * * For sending push notifications to Android devices using Google's firebase cloud messaging (FCM) API
-     * - firebase.apikey: String containing the FCM API key
+     * - firebase.projectId: String containing the FCM project ID
+     * - firebase.credentialsFile: the name of the json file containing the service account key
      *
      * - devicestorage: An array with the configuration of the storage for device push notification tokens. Only
      *                  necessary if you use the Tiqr Service to authenticate an already known userId (e.g. when using

--- a/run-docker-testserver.sh
+++ b/run-docker-testserver.sh
@@ -8,4 +8,4 @@ CONFIG_DIR="${SCRIPT_DIR}/TestServer/config/"
 echo CONFIG_DIR="${CONFIG_DIR}"
 STORAGE_DIR="${SCRIPT_DIR}/TestServer/storage/"
 echo STORAGE_DIR="${STORAGE_DIR}"
-docker run -it --rm -v "${CONFIG_DIR}:/var/www/TestServer/config" -v "${STORAGE_DIR}:/var/www/TestServer/storage" -p 8000:80/tcp tiqr-testserver:latest
+docker run -it --rm -v "${CONFIG_DIR}:/var/www/TestServer/config" -v "${STORAGE_DIR}:/var/www/TestServer/storage" --name tiqr-testserver -p 8000:80/tcp tiqr-testserver:latest


### PR DESCRIPTION
See 
- https://www.pivotaltracker.com/story/show/185509567
- https://firebase.google.com/docs/cloud-messaging/migrate-v1

2do:

- [x]  Make google-service.json configurable
- [x]  Make your-project-id configurable
- [x] Update testserver to use the new API
- [x]  Update README
- [x] Move tokenexchange communication form fopen to curl
- [x]  Add caching for accesstokens
- [x] Add logging for accesstoken caching
