### PR TITLE
Migrate to symfony/cache for Symfony 7.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,13 @@
         "ext-gd": "*",
         "ext-curl": "*",
         "ext-json": "*",
-        "psr/log": "^3.0",
-        "edamov/pushok": "^0.16.0",
         "ext-openssl": "*",
+        "psr/log": "^3.0",
+        "psr/cache": "^3.0",
+        "edamov/pushok": "^0.16.0",
         "chillerlan/php-qrcode": "^3.4",
         "google/apiclient": "^2.14",
-        "cache/filesystem-adapter": "^1"
+        "symfony/cache": "^6.4|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/library/tiqr/Tiqr/Message/FCM.php
+++ b/library/tiqr/Tiqr/Message/FCM.php
@@ -16,9 +16,7 @@
  *
  * @copyright (C) 2010-2024 SURF BV
  */
-use League\Flysystem\Adapter\Local;
-use League\Flysystem\Filesystem;
-use Cache\Adapter\Filesystem\FilesystemCachePool;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 /**
  * Android Cloud To Device Messaging message.
@@ -58,9 +56,11 @@ class Tiqr_Message_FCM extends Tiqr_Message_Abstract
         // Try to add a file based cache for accesstokens, if configured
         if ($cacheTokens) {
             //set up the cache
-            $filesystemAdapter = new Local($tokenCacheDir);
-            $filesystem = new Filesystem($filesystemAdapter);
-            $pool = new FilesystemCachePool($filesystem);
+            $pool = new FilesystemAdapter(
+                namespace: 'firebase_tokens',
+                defaultLifetime: 0,
+                directory: $tokenCacheDir
+            );
 
             //set up a callback to log token refresh
             $logger=$this->logger;


### PR DESCRIPTION
This package is very old and doesnt look like its being updated as the last release was in 2022. Also the repo is read-only.

Therefore, i have decide to migrate to symfony/cache 

ref: https://github.com/php-cache/filesystem-adapter/pull/11