### PR TITLE
Fix PHP 8.4/8.5 deprecations

### DIFF
--- a/library/tiqr/Tiqr/DeviceStorage.php
+++ b/library/tiqr/Tiqr/DeviceStorage.php
@@ -40,7 +40,7 @@ class Tiqr_DeviceStorage
      * @param LoggerInterface $logger
      * @throws Exception An exception if an unknown storage is requested.
      */
-    public static function getStorage(string $type="dummy", Array $options=array(), LoggerInterface $logger=null)
+    public static function getStorage(string $type="dummy", Array $options=array(), ?LoggerInterface $logger=null)
     {
         if (!$logger)
             $logger=new \Psr\Log\NullLogger();

--- a/library/tiqr/Tiqr/Message/Exception/MismatchSenderId.php
+++ b/library/tiqr/Tiqr/Message/Exception/MismatchSenderId.php
@@ -29,8 +29,8 @@ class Tiqr_Message_Exception_MismatchSenderId extends Tiqr_Message_Exception
      * Constructor
      *
      * @param string    $message    exception message
-     * @param boolean   $temporary  temporary failure?
-     * @param Exception $parent     parent exception
+     * @param bool      $temporary  temporary failure?
+     * @param Exception|null $parent    parent exception
      */
     public function __construct($message, $temporary=false, ?Exception $parent=null)
     {

--- a/library/tiqr/Tiqr/Message/Exception/MismatchSenderId.php
+++ b/library/tiqr/Tiqr/Message/Exception/MismatchSenderId.php
@@ -32,7 +32,7 @@ class Tiqr_Message_Exception_MismatchSenderId extends Tiqr_Message_Exception
      * @param boolean   $temporary  temporary failure?
      * @param Exception $parent     parent exception
      */
-    public function __construct($message, $temporary=false, Exception $parent=null)
+    public function __construct($message, $temporary=false, ?Exception $parent=null)
     {
         parent::__construct($message, $parent);
         $this->_temporary = $temporary;

--- a/library/tiqr/Tiqr/Message/Exception/SendFailure.php
+++ b/library/tiqr/Tiqr/Message/Exception/SendFailure.php
@@ -32,7 +32,7 @@ class Tiqr_Message_Exception_SendFailure extends Tiqr_Message_Exception
      * @param boolean   $temporary  temporary failure?
      * @param Exception $parent     parent exception
      */
-    public function __construct($message, $temporary=false, Exception $parent=null)
+    public function __construct($message, $temporary=false, ?Exception $parent=null)
     {
         parent::__construct($message, $parent);
         $this->_temporary = $temporary;

--- a/library/tiqr/Tiqr/Message/Exception/SendFailure.php
+++ b/library/tiqr/Tiqr/Message/Exception/SendFailure.php
@@ -29,8 +29,8 @@ class Tiqr_Message_Exception_SendFailure extends Tiqr_Message_Exception
      * Constructor
      *
      * @param string    $message    exception message
-     * @param boolean   $temporary  temporary failure?
-     * @param Exception $parent     parent exception
+     * @param bool      $temporary  temporary failure?
+     * @param Exception|null $parent    parent exception
      */
     public function __construct($message, $temporary=false, ?Exception $parent=null)
     {

--- a/library/tiqr/Tiqr/OATH/OCRA.php
+++ b/library/tiqr/Tiqr/OATH/OCRA.php
@@ -140,7 +140,7 @@ class OCRA {
         if (! ctype_digit($codeDigits_str)) {
             throw new InvalidArgumentException('Unsupported OCRA CryptoFunction');
         }
-        $codeDigits = (integer)$codeDigits_str;
+        $codeDigits = (int)$codeDigits_str;
         if (($codeDigits != 0) && (($codeDigits < 4) || ($codeDigits > 10))) {
             throw new InvalidArgumentException('Unsupported OCRA CryptoFunction');
         }

--- a/library/tiqr/Tiqr/OATH/OCRAParser.php
+++ b/library/tiqr/Tiqr/OATH/OCRAParser.php
@@ -233,7 +233,7 @@ class OATH_OCRAParser {
 			$result &= ($s1[$i] == $s2[$i]);
 		}
 
-		return (boolean)$result;
+		return (bool)$result;
 	}
 
 }

--- a/library/tiqr/Tiqr/OcraService.php
+++ b/library/tiqr/Tiqr/OcraService.php
@@ -37,7 +37,7 @@ class Tiqr_OcraService
      * @return Tiqr_OcraService_Interface
      * @throws Exception An exception if an unknown orca service type is requested.
      */
-    public static function getOcraService(string $type="tiqr", array $options=array(), LoggerInterface $logger=null)
+    public static function getOcraService(string $type="tiqr", array $options=array(), ?LoggerInterface $logger=null)
     {
         if (!$logger)
             $logger=new \Psr\Log\NullLogger();

--- a/library/tiqr/Tiqr/Service.php
+++ b/library/tiqr/Tiqr/Service.php
@@ -334,7 +334,7 @@ class Tiqr_Service
      * @param string $serviceName Display name of the service being authenticated
      * @throws Tiqr_Message_Exception_SendFailure
      */
-    public function sendAuthNotification(string $sessionKey, string $notificationType, string $notificationAddress, string $serviceName = null): void
+    public function sendAuthNotification(string $sessionKey, string $notificationType, string $notificationAddress, ?string $serviceName = null): void
     {
         $message = NULL;
         try {

--- a/library/tiqr/tests/OcraTest.php
+++ b/library/tiqr/tests/OcraTest.php
@@ -299,7 +299,6 @@ class OcraTest extends TestCase
 
         $classOCRA = new ReflectionClass('OCRA');
         $_hexStr2Bytes = $classOCRA->getMethod("_hexStr2Bytes");
-        $_hexStr2Bytes->setAccessible(true);
 
         if ( $expected instanceof Exception ) {
             $this->expectExceptionObject($expected);

--- a/library/tiqr/tests/Tiqr_UserSecretStorage_Encryption_OpenSSLTest.php
+++ b/library/tiqr/tests/Tiqr_UserSecretStorage_Encryption_OpenSSLTest.php
@@ -65,7 +65,6 @@ class Tiqr_UserSecretStorage_Encryption_OpenSSLTest extends TestCase
         $enc=new Tiqr_UserSecretStorage_Encryption_OpenSSL(['cipher' => 'aes-128-cbc', 'keys' => array('default' => '0102030405060708090a0b0c0d0e0f10')]);
         $reflection = new ReflectionClass($enc);
         $property = $reflection->getProperty('_supportedCiphers');
-        $property->setAccessible(true);
         $supportedCiphers=$property->getValue($enc);
 
         $testKey='0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20';


### PR DESCRIPTION
PHP 8.4 deprecates [implicitly nullable parameter types](https://www.php.net/manual/en/migration84.deprecated.php) and PHP 8.5 deprecates non-canonical casts and `Reflection*::setAccessible()`. The implicit-nullable deprecations are emitted at **compile time**, i.e. as soon as the affected class is loaded. This breaks consumers that promote deprecations to exceptions — for example Behat in [OpenConext/Stepup-tiqr#402](https://github.com/OpenConext/Stepup-tiqr/pull/402), where the first scenario fails with:

```
Deprecated: Tiqr_DeviceStorage::getStorage(): Implicitly marking parameter $logger as nullable is deprecated,
the explicit nullable type must be used instead in library/tiqr/Tiqr/DeviceStorage.php line 43
```

### Changes
- Explicit nullable types (`?Type $param = null`) in `Tiqr_DeviceStorage::getStorage()`, `Tiqr_OcraService::getOcraService()`, `Tiqr_Service::sendAuthNotification()`, `Tiqr_Message_Exception_MismatchSenderId` and `Tiqr_Message_Exception_SendFailure`
- `(boolean)` → `(bool)` in `OCRAParser`, `(integer)` → `(int)` in `OCRA`
- Removed `setAccessible(true)` calls in tests (no-op since PHP 8.1, deprecated in 8.5)

No behavioural changes; all signatures already accepted/handled `null`.

### Verification
`find library -name '*.php' -exec php -l {} \;` on PHP 8.5 is deprecation-free, and `./ci/qa/phpunit` passes: `OK (277 tests, 677 assertions)`.