### PR TITLE
Upgrade chillerlan/php-qrcode to ^4.4 for PHP 8.4/8.5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 4.4.2
-* Upgrade `chillerlan/php-qrcode` from `^3.4` to `^4.4` to resolve PHP 8.4/8.5 implicit nullable deprecation in `chillerlan/php-settings-container` 1.x ([#63](https://github.com/Tiqr/tiqr-server-libphp/pull/63))
+* Upgrade `chillerlan/php-qrcode` from `^3.4` to `^5.0` to resolve PHP 8.4/8.5 implicit nullable deprecations in `chillerlan/php-settings-container` 1.x and the `imagedestroy()` deprecation in PHP 8.5 ([#63](https://github.com/Tiqr/tiqr-server-libphp/pull/63))
 * Upgrade `edamov/pushok` from `^0.16` to `^0.19` to resolve PHP 8.4/8.5 implicit nullable deprecations in `Pushok\Payload\Alert` and `Pushok\Response` ([#63](https://github.com/Tiqr/tiqr-server-libphp/pull/63))
 
 ## 4.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.4.2
 * Upgrade `chillerlan/php-qrcode` from `^3.4` to `^4.4` to resolve PHP 8.4/8.5 implicit nullable deprecation in `chillerlan/php-settings-container` 1.x ([#63](https://github.com/Tiqr/tiqr-server-libphp/pull/63))
+* Upgrade `edamov/pushok` from `^0.16` to `^0.19` to resolve PHP 8.4/8.5 implicit nullable deprecations in `Pushok\Payload\Alert` and `Pushok\Response` ([#63](https://github.com/Tiqr/tiqr-server-libphp/pull/63))
 
 ## 4.4.1
 * Fix PHP 8.4/8.5 deprecations: use explicit nullable types (`?Type $param = null`) in `Tiqr_DeviceStorage::getStorage()`, `Tiqr_OcraService::getOcraService()`, `Tiqr_Service::sendAuthNotification()` and the `Tiqr_Message` exceptions ([#62](https://github.com/Tiqr/tiqr-server-libphp/pull/62))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.4.2
+* Upgrade `chillerlan/php-qrcode` from `^3.4` to `^4.4` to resolve PHP 8.4/8.5 implicit nullable deprecation in `chillerlan/php-settings-container` 1.x ([#63](https://github.com/Tiqr/tiqr-server-libphp/pull/63))
+
 ## 4.4.1
 * Fix PHP 8.4/8.5 deprecations: use explicit nullable types (`?Type $param = null`) in `Tiqr_DeviceStorage::getStorage()`, `Tiqr_OcraService::getOcraService()`, `Tiqr_Service::sendAuthNotification()` and the `Tiqr_Message` exceptions ([#62](https://github.com/Tiqr/tiqr-server-libphp/pull/62))
 * Replace non-canonical `(boolean)` and `(integer)` casts with `(bool)` and `(int)` ([#62](https://github.com/Tiqr/tiqr-server-libphp/pull/62))

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr/log": "^3.0",
         "psr/cache": "^3.0",
         "edamov/pushok": "^0.19",
-        "chillerlan/php-qrcode": "^4.4",
+        "chillerlan/php-qrcode": "^5.0",
         "google/apiclient": "^2.14",
         "symfony/cache": "^6.4|^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-openssl": "*",
         "psr/log": "^3.0",
         "psr/cache": "^3.0",
-        "edamov/pushok": "^0.16.0",
+        "edamov/pushok": "^0.19",
         "chillerlan/php-qrcode": "^4.4",
         "google/apiclient": "^2.14",
         "symfony/cache": "^6.4|^7.0"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr/log": "^3.0",
         "psr/cache": "^3.0",
         "edamov/pushok": "^0.16.0",
-        "chillerlan/php-qrcode": "^3.4",
+        "chillerlan/php-qrcode": "^4.4",
         "google/apiclient": "^2.14",
         "symfony/cache": "^6.4|^7.0"
     },


### PR DESCRIPTION
## Problem

`php-qrcode ^3.4` depends on `chillerlan/php-settings-container ^1.2.2`. Version 1.x of that library has implicit nullable parameters deprecated in PHP 8.4+:

```
Deprecated: chillerlan\Settings\SettingsContainerAbstract::__construct():
Implicitly marking parameter $properties as nullable is deprecated in
php-settings-container/src/SettingsContainerAbstract.php line 26
```

This surfaces in consumers that promote deprecations to exceptions (e.g. Behat in Stepup-tiqr) and causes test failures on PHP 8.4+.

## Fix

Upgrade to `chillerlan/php-qrcode ^4.4` which requires `php-settings-container ^3.3` — fixed upstream. The API used by this library (`QRCode::ECC_L`, `QRCode::OUTPUT_IMAGE_PNG`, `QROptions`, `->render()`) is unchanged between 3.x and 4.x.

## Verification

- `find library -name '*.php' -exec php -l {} \;` on PHP 8.5: zero deprecations
- `./ci/qa/phpunit`: OK (277 tests, 677 assertions)